### PR TITLE
Allow options to be disabled

### DIFF
--- a/src/components/FormSelect/index.tsx
+++ b/src/components/FormSelect/index.tsx
@@ -75,7 +75,7 @@ export function FormSelect({
           {placeholder || 'Select'}
         </MenuItem>
         {options.map(item => (
-          <MenuItem key={item.value} value={item.value}>
+          <MenuItem disabled={item.disabled} key={item.value} value={item.value}>
             {item.label}
           </MenuItem>
         ))}

--- a/src/components/FormSelect/index.tsx
+++ b/src/components/FormSelect/index.tsx
@@ -21,6 +21,7 @@ import { AlertOutline } from '~/icons';
 import { InputLabel, InputLabelProps } from '~/components/InputLabel';
 
 export interface SelectOption {
+  disabled?: boolean;
   label: string | null;
   value: number | string;
 }
@@ -75,7 +76,11 @@ export function FormSelect({
           {placeholder || 'Select'}
         </MenuItem>
         {options.map(item => (
-          <MenuItem disabled={item.disabled} key={item.value} value={item.value}>
+          <MenuItem
+            disabled={item.disabled}
+            key={item.value}
+            value={item.value}
+          >
             {item.label}
           </MenuItem>
         ))}


### PR DESCRIPTION
This change allows a consumer of the FormSelect component to disable options by passing a 'disabled' boolean value as part of the option.