### PR TITLE
chore: Added custom useLocalStorage react hook to replace react-use-l…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Chronological history of changes to the Design Language System.
 
+## [v5.5.2] - Aug 06, 2021
+
+* Added `useLocalStorage` hook, which replaces the NPM package `react-use-localstorage`. 
+
 ## [v5.5.1] - July 29, 2021
 
 * Fixes the `ReferenceError: regeneratorRuntime is not defined` exception in

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@actinc/dls",
-  "version": "5.5.1",
+  "version": "5.5.2-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22657,11 +22657,6 @@
         "prop-types": "^15.6.2"
       }
     },
-    "react-use-localstorage": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/react-use-localstorage/-/react-use-localstorage-3.5.3.tgz",
-      "integrity": "sha512-1oNvJmo72G4v5P9ytJZZTb6ywD3UzWBiainTtfbNlb+U08hc+SOD5HqgiLTKUF0MxGcIR9JSnZGmBttNLXaQYA=="
-    },
     "read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-idle-timer": "^4.6.4",
-    "react-use-localstorage": "^3.5.3",
     "validator": "^13.5.2"
   },
   "description": "Design Language System (DLS) for ACT front-end projects.",

--- a/package.json
+++ b/package.json
@@ -147,5 +147,5 @@
     "test:outdated": "npm outdated"
   },
   "types": "index.d.ts",
-  "version": "5.5.1"
+  "version": "5.5.2-0"
 }

--- a/src/components/SessionStorageKeySharer/index.tsx
+++ b/src/components/SessionStorageKeySharer/index.tsx
@@ -9,7 +9,8 @@
 
 import * as React from 'react';
 import JSONParseSafe from 'json-parse-safe';
-import useLocalStorage from 'react-use-localstorage';
+
+import useLocalStorage from '~/hooks/useLocalStorage';
 
 export interface SessionStorageKeySharerProps {
   keyName: string;

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) ACT, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @prettier
+ */
+
+/* eslint-disable import/prefer-default-export */
+
+export { default as useLocalStorage } from './useLocalStorage';

--- a/src/hooks/useLocalStorage.tsx
+++ b/src/hooks/useLocalStorage.tsx
@@ -1,0 +1,58 @@
+/**
+ * @prettier
+ */
+
+import * as React from 'react';
+import { isFunction } from 'lodash';
+
+const useLocalStorage = (
+  key: string,
+  initValue = '',
+): [string, (v: string) => void] => {
+  const [storedValue, setStoredValue] = React.useState(() => {
+    try {
+      const item = window.localStorage.getItem(key);
+
+      return item || initValue;
+    } catch (err) {
+      console.error(err);
+      return initValue;
+    }
+  });
+
+  const handleStorage = (e: StorageEvent): void => {
+    if (e.key === key && e.newValue !== storedValue) {
+      setStoredValue(e.newValue || initValue);
+    }
+  };
+
+  React.useEffect(() => {
+    try {
+      window.addEventListener('storage', handleStorage);
+    } catch (err) {
+      console.error(err);
+    }
+
+    return (): void => {
+      try {
+        window.removeEventListener('storage', handleStorage);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+  }, []);
+
+  const updateStoredValue = (value: string | ((v: string) => string)): void => {
+    try {
+      const valueToStore = isFunction(value) ? value(storedValue) : value;
+      setStoredValue(valueToStore);
+      window.localStorage.setItem(key, JSON.stringify(valueToStore));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return [storedValue, updateStoredValue];
+};
+
+export default useLocalStorage;


### PR DESCRIPTION
We encountered some build problems in a project that were related to the use of `react-use-localstorage` package in DLS. By creating a custom react hook that makes the localStorage reactive we hope the problems are going to be fixed.