### PR TITLE
[5.9.0]: Added Optional Pagination to <DataTable /> Component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 Chronological history of changes to the Design Language System.
 
+## [v5.9.0] - Dec 06, 2021
+
+* New component: `<TablePaginationActions />`
+  * Useful for paginating large lists and tables
+* Enhanced `<DataTable />` component with `<TablePaginationActions />` and
+optional props to support server-side pagination:
+
+    ```ts
+    limit?: number;
+    offset?: number;
+    onChangeLimit?: (limit: number) => void;
+    onChangeOffset?: (offset: number) => void;
+    rowsPerPageOptions?: number[];
+    totalCount?: number;
+    ```
+
 ## [v5.8.1] - Nov 03, 2021
 
 * Bind `this` to `addError` in `AlertContext`.
@@ -26,7 +42,7 @@ under the hood, since this is now the preferred way to add inputs to your app.
 ## [v5.5.2] - Aug 06, 2021
 
 * Added `useLocalStorage` hook, which replaces the NPM package
-`react-use-localstorage`. 
+`react-use-localstorage`.
 
 ## [v5.5.1] - July 29, 2021
 
@@ -133,8 +149,8 @@ tab.
 
 ## [v5.1.0] - June 15, 2021
 
-* Updated `<FormSelect />` component to allow options to be disabled. See:
-https://github.com/act-org/dls/pull/9
+* Updated `<FormSelect />` component to allow options to be disabled.
+([Pull Request](https://github.com/act-org/dls/pull/9))
 
 ## [v5.0.0] - June 07, 2021
 
@@ -171,7 +187,7 @@ component, courtesy of @stefansolyom.
 * The DLS has been completely rebuilt on top of the Material UI
 [theme engine](https://material-ui.com/customization/theming/).
   * There are two UI themes that are provided out of the box:
-  `ACT` and `ACT_ET`. 
+  `ACT` and `ACT_ET`.
   * Refer to the README for usage instructions and more details.
 
 ## [v3.1.0] - March 05, 2021

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@actinc/dls",
-  "version": "5.8.1",
+  "version": "5.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5926,6 +5926,15 @@
         "@types/react": "*"
       }
     },
+    "@types/react-window": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@types/react-window/-/react-window-1.8.5.tgz",
+      "integrity": "sha512-V9q3CvhC9Jk9bWBOysPGaWy/Z0lxYcTXLtLipkt2cnRj1JOSFNF7wqGpkScSXMgBwC+fnVRg/7shwgddBG5ICw==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/responselike": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
@@ -18762,8 +18771,7 @@
     "memoize-one": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
-      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
-      "dev": true
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
     "memoizerific": {
       "version": "1.11.3",
@@ -22655,6 +22663,15 @@
         "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
+      }
+    },
+    "react-window": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.6.tgz",
+      "integrity": "sha512-8VwEEYyjz6DCnGBsd+MgkD0KJ2/OXFULyDtorIiTz+QzwoP94tBoA7CnbtyXMm+cCeAUER5KJcPtWl9cpKbOBg==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
       }
     },
     "read": {

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "start": "start-storybook -p 6006 --no-manager-cache",
     "test": "npm-run-all test:**",
     "test:lint:js": "eslint . --ext .js --fix --quiet",
-    "test:lint:md": "markdownlint README.md --config node_modules/@actinc/eslint-config/markdownlint.config.json",
+    "test:lint:md": "markdownlint *.md --config node_modules/@actinc/eslint-config/markdownlint.config.json",
     "test:lint:ts": "eslint . --ext .ts,.tsx --fix --quiet",
     "test:types": "tsc --noEmit",
     "test:unit": "jest --maxWorkers=2 --verbose",

--- a/package.json
+++ b/package.json
@@ -149,5 +149,5 @@
     "test:outdated": "npm outdated"
   },
   "types": "index.d.ts",
-  "version": "5.8.1"
+  "version": "5.9.0"
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-idle-timer": "^4.6.4",
+    "react-window": "^1.8.6",
     "validator": "^13.5.2"
   },
   "description": "Design Language System (DLS) for ACT front-end projects.",
@@ -55,6 +56,7 @@
     "@types/pluralize": "0.0.29",
     "@types/react": "17.0.15",
     "@types/react-dom": "17.0.9",
+    "@types/react-window": "1.8.5",
     "@types/shelljs": "0.8.9",
     "@types/validator": "13.6.3",
     "axe-core": "4.3.2",

--- a/src/components/DataTable/__snapshots__/index.test.tsx.snap
+++ b/src/components/DataTable/__snapshots__/index.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`DataTable ACT theme matches the snapshot 1`] = `
 <div>
   <div
-    class="MuiPaper-root makeStyles-paperRoot-2 MuiTableContainer-root MuiPaper-elevation0 MuiPaper-rounded"
+    class="MuiPaper-root makeStyles-paperRoot-3 MuiTableContainer-root MuiPaper-elevation0 MuiPaper-rounded"
   >
     <table
       class="MuiTable-root"
@@ -15,22 +15,22 @@ exports[`DataTable ACT theme matches the snapshot 1`] = `
           class="MuiTableRow-root MuiTableRow-head"
         >
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-5 makeStyles-tableCellRoot-8 MuiTableCell-head"
+            class="MuiTableCell-root makeStyles-tableCellRoot-6 makeStyles-tableCellRoot-9 MuiTableCell-head"
             role="columnheader"
             scope="col"
             style="width: 50px;"
           >
             <p
-              class="MuiTypography-root makeStyles-typographyRoot-6 makeStyles-typographyRoot-9 MuiTypography-body1"
+              class="MuiTypography-root makeStyles-typographyRoot-7 makeStyles-typographyRoot-10 MuiTypography-body1"
             >
               ID
             </p>
             <div
-              class="MuiGrid-root makeStyles-sortContainerRoot-3 MuiGrid-container"
+              class="MuiGrid-root makeStyles-sortContainerRoot-4 MuiGrid-container"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root makeStyles-sortIconRoot-4 makeStyles-sortIconRoot-7"
+                class="MuiSvgIcon-root makeStyles-sortIconRoot-5 makeStyles-sortIconRoot-8"
                 focusable="false"
                 role="button"
                 style="color: rgb(0, 0, 0);"
@@ -42,7 +42,7 @@ exports[`DataTable ACT theme matches the snapshot 1`] = `
               </svg>
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root makeStyles-sortIconRoot-4 makeStyles-sortIconRoot-7"
+                class="MuiSvgIcon-root makeStyles-sortIconRoot-5 makeStyles-sortIconRoot-8"
                 focusable="false"
                 role="button"
                 viewBox="9 7 5 15"
@@ -54,22 +54,22 @@ exports[`DataTable ACT theme matches the snapshot 1`] = `
             </div>
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-5 makeStyles-tableCellRoot-11 MuiTableCell-head"
+            class="MuiTableCell-root makeStyles-tableCellRoot-6 makeStyles-tableCellRoot-12 MuiTableCell-head"
             role="columnheader"
             scope="col"
             style="width: 100px;"
           >
             <p
-              class="MuiTypography-root makeStyles-typographyRoot-6 makeStyles-typographyRoot-12 MuiTypography-body1"
+              class="MuiTypography-root makeStyles-typographyRoot-7 makeStyles-typographyRoot-13 MuiTypography-body1"
             >
               Name
             </p>
             <div
-              class="MuiGrid-root makeStyles-sortContainerRoot-3 MuiGrid-container"
+              class="MuiGrid-root makeStyles-sortContainerRoot-4 MuiGrid-container"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root makeStyles-sortIconRoot-4 makeStyles-sortIconRoot-10"
+                class="MuiSvgIcon-root makeStyles-sortIconRoot-5 makeStyles-sortIconRoot-11"
                 focusable="false"
                 role="button"
                 viewBox="9 3 5 15"
@@ -80,7 +80,7 @@ exports[`DataTable ACT theme matches the snapshot 1`] = `
               </svg>
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root makeStyles-sortIconRoot-4 makeStyles-sortIconRoot-10"
+                class="MuiSvgIcon-root makeStyles-sortIconRoot-5 makeStyles-sortIconRoot-11"
                 focusable="false"
                 role="button"
                 viewBox="9 7 5 15"
@@ -92,22 +92,22 @@ exports[`DataTable ACT theme matches the snapshot 1`] = `
             </div>
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-5 makeStyles-tableCellRoot-14 MuiTableCell-head"
+            class="MuiTableCell-root makeStyles-tableCellRoot-6 makeStyles-tableCellRoot-15 MuiTableCell-head"
             role="columnheader"
             scope="col"
             style="width: 100px;"
           >
             <p
-              class="MuiTypography-root makeStyles-typographyRoot-6 makeStyles-typographyRoot-15 MuiTypography-body1"
+              class="MuiTypography-root makeStyles-typographyRoot-7 makeStyles-typographyRoot-16 MuiTypography-body1"
             >
               Field A
             </p>
             <div
-              class="MuiGrid-root makeStyles-sortContainerRoot-3 MuiGrid-container"
+              class="MuiGrid-root makeStyles-sortContainerRoot-4 MuiGrid-container"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root makeStyles-sortIconRoot-4 makeStyles-sortIconRoot-13"
+                class="MuiSvgIcon-root makeStyles-sortIconRoot-5 makeStyles-sortIconRoot-14"
                 focusable="false"
                 role="button"
                 viewBox="9 3 5 15"
@@ -118,7 +118,7 @@ exports[`DataTable ACT theme matches the snapshot 1`] = `
               </svg>
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root makeStyles-sortIconRoot-4 makeStyles-sortIconRoot-13"
+                class="MuiSvgIcon-root makeStyles-sortIconRoot-5 makeStyles-sortIconRoot-14"
                 focusable="false"
                 role="button"
                 viewBox="9 7 5 15"
@@ -130,22 +130,22 @@ exports[`DataTable ACT theme matches the snapshot 1`] = `
             </div>
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-5 makeStyles-tableCellRoot-17 MuiTableCell-head"
+            class="MuiTableCell-root makeStyles-tableCellRoot-6 makeStyles-tableCellRoot-18 MuiTableCell-head"
             role="columnheader"
             scope="col"
             style="width: 100px;"
           >
             <p
-              class="MuiTypography-root makeStyles-typographyRoot-6 makeStyles-typographyRoot-18 MuiTypography-body1"
+              class="MuiTypography-root makeStyles-typographyRoot-7 makeStyles-typographyRoot-19 MuiTypography-body1"
             >
               Field B
             </p>
             <div
-              class="MuiGrid-root makeStyles-sortContainerRoot-3 MuiGrid-container"
+              class="MuiGrid-root makeStyles-sortContainerRoot-4 MuiGrid-container"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root makeStyles-sortIconRoot-4 makeStyles-sortIconRoot-16"
+                class="MuiSvgIcon-root makeStyles-sortIconRoot-5 makeStyles-sortIconRoot-17"
                 focusable="false"
                 role="button"
                 viewBox="9 3 5 15"
@@ -156,7 +156,7 @@ exports[`DataTable ACT theme matches the snapshot 1`] = `
               </svg>
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root makeStyles-sortIconRoot-4 makeStyles-sortIconRoot-16"
+                class="MuiSvgIcon-root makeStyles-sortIconRoot-5 makeStyles-sortIconRoot-17"
                 focusable="false"
                 role="button"
                 viewBox="9 7 5 15"
@@ -168,22 +168,22 @@ exports[`DataTable ACT theme matches the snapshot 1`] = `
             </div>
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-5 makeStyles-tableCellRoot-20 MuiTableCell-head"
+            class="MuiTableCell-root makeStyles-tableCellRoot-6 makeStyles-tableCellRoot-21 MuiTableCell-head"
             role="columnheader"
             scope="col"
             style="width: 100px;"
           >
             <p
-              class="MuiTypography-root makeStyles-typographyRoot-6 makeStyles-typographyRoot-21 MuiTypography-body1"
+              class="MuiTypography-root makeStyles-typographyRoot-7 makeStyles-typographyRoot-22 MuiTypography-body1"
             >
               Field C
             </p>
             <div
-              class="MuiGrid-root makeStyles-sortContainerRoot-3 MuiGrid-container"
+              class="MuiGrid-root makeStyles-sortContainerRoot-4 MuiGrid-container"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root makeStyles-sortIconRoot-4 makeStyles-sortIconRoot-19"
+                class="MuiSvgIcon-root makeStyles-sortIconRoot-5 makeStyles-sortIconRoot-20"
                 focusable="false"
                 role="button"
                 viewBox="9 3 5 15"
@@ -194,7 +194,7 @@ exports[`DataTable ACT theme matches the snapshot 1`] = `
               </svg>
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root makeStyles-sortIconRoot-4 makeStyles-sortIconRoot-19"
+                class="MuiSvgIcon-root makeStyles-sortIconRoot-5 makeStyles-sortIconRoot-20"
                 focusable="false"
                 role="button"
                 viewBox="9 7 5 15"
@@ -214,35 +214,35 @@ exports[`DataTable ACT theme matches the snapshot 1`] = `
           class="MuiTableRow-root MuiTableRow-hover"
         >
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-22 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-23 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 50px;"
           >
             1
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-22 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-23 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
             Item 1
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-22 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-23 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
             Field A1
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-22 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-23 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
             Field B1
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-22 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-23 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
@@ -253,35 +253,35 @@ exports[`DataTable ACT theme matches the snapshot 1`] = `
           class="MuiTableRow-root MuiTableRow-hover"
         >
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-22 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-23 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 50px;"
           >
             2
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-22 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-23 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
             Item 2
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-22 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-23 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
             Field A2
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-22 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-23 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
             Field B2
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-22 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-23 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
@@ -292,35 +292,35 @@ exports[`DataTable ACT theme matches the snapshot 1`] = `
           class="MuiTableRow-root MuiTableRow-hover"
         >
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-22 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-23 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 50px;"
           >
             3
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-22 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-23 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
             Item 3
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-22 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-23 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
             Field A3
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-22 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-23 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
             Field B3
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-22 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-23 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
@@ -331,35 +331,35 @@ exports[`DataTable ACT theme matches the snapshot 1`] = `
           class="MuiTableRow-root MuiTableRow-hover"
         >
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-22 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-23 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 50px;"
           >
             4
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-22 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-23 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
             Item 4
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-22 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-23 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
             Field A4
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-22 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-23 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
             Field B4
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-22 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-23 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
@@ -370,35 +370,35 @@ exports[`DataTable ACT theme matches the snapshot 1`] = `
           class="MuiTableRow-root MuiTableRow-hover"
         >
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-22 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-23 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 50px;"
           >
             5
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-22 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-23 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
             Item 5
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-22 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-23 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
             Field A5
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-22 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-23 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
             Field B5
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-22 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-23 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
@@ -414,7 +414,7 @@ exports[`DataTable ACT theme matches the snapshot 1`] = `
 exports[`DataTable ACT_ET theme matches the snapshot 1`] = `
 <div>
   <div
-    class="MuiPaper-root makeStyles-paperRoot-24 MuiTableContainer-root MuiPaper-elevation0 MuiPaper-rounded"
+    class="MuiPaper-root makeStyles-paperRoot-26 MuiTableContainer-root MuiPaper-elevation0 MuiPaper-rounded"
   >
     <table
       class="MuiTable-root"
@@ -426,22 +426,22 @@ exports[`DataTable ACT_ET theme matches the snapshot 1`] = `
           class="MuiTableRow-root MuiTableRow-head"
         >
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-27 makeStyles-tableCellRoot-30 MuiTableCell-head"
+            class="MuiTableCell-root makeStyles-tableCellRoot-29 makeStyles-tableCellRoot-32 MuiTableCell-head"
             role="columnheader"
             scope="col"
             style="width: 50px;"
           >
             <p
-              class="MuiTypography-root makeStyles-typographyRoot-28 makeStyles-typographyRoot-31 MuiTypography-body1"
+              class="MuiTypography-root makeStyles-typographyRoot-30 makeStyles-typographyRoot-33 MuiTypography-body1"
             >
               ID
             </p>
             <div
-              class="MuiGrid-root makeStyles-sortContainerRoot-25 MuiGrid-container"
+              class="MuiGrid-root makeStyles-sortContainerRoot-27 MuiGrid-container"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root makeStyles-sortIconRoot-26 makeStyles-sortIconRoot-29"
+                class="MuiSvgIcon-root makeStyles-sortIconRoot-28 makeStyles-sortIconRoot-31"
                 focusable="false"
                 role="button"
                 style="color: rgb(0, 0, 0);"
@@ -453,7 +453,7 @@ exports[`DataTable ACT_ET theme matches the snapshot 1`] = `
               </svg>
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root makeStyles-sortIconRoot-26 makeStyles-sortIconRoot-29"
+                class="MuiSvgIcon-root makeStyles-sortIconRoot-28 makeStyles-sortIconRoot-31"
                 focusable="false"
                 role="button"
                 viewBox="9 7 5 15"
@@ -465,22 +465,22 @@ exports[`DataTable ACT_ET theme matches the snapshot 1`] = `
             </div>
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-27 makeStyles-tableCellRoot-33 MuiTableCell-head"
+            class="MuiTableCell-root makeStyles-tableCellRoot-29 makeStyles-tableCellRoot-35 MuiTableCell-head"
             role="columnheader"
             scope="col"
             style="width: 100px;"
           >
             <p
-              class="MuiTypography-root makeStyles-typographyRoot-28 makeStyles-typographyRoot-34 MuiTypography-body1"
+              class="MuiTypography-root makeStyles-typographyRoot-30 makeStyles-typographyRoot-36 MuiTypography-body1"
             >
               Name
             </p>
             <div
-              class="MuiGrid-root makeStyles-sortContainerRoot-25 MuiGrid-container"
+              class="MuiGrid-root makeStyles-sortContainerRoot-27 MuiGrid-container"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root makeStyles-sortIconRoot-26 makeStyles-sortIconRoot-32"
+                class="MuiSvgIcon-root makeStyles-sortIconRoot-28 makeStyles-sortIconRoot-34"
                 focusable="false"
                 role="button"
                 viewBox="9 3 5 15"
@@ -491,7 +491,7 @@ exports[`DataTable ACT_ET theme matches the snapshot 1`] = `
               </svg>
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root makeStyles-sortIconRoot-26 makeStyles-sortIconRoot-32"
+                class="MuiSvgIcon-root makeStyles-sortIconRoot-28 makeStyles-sortIconRoot-34"
                 focusable="false"
                 role="button"
                 viewBox="9 7 5 15"
@@ -503,22 +503,22 @@ exports[`DataTable ACT_ET theme matches the snapshot 1`] = `
             </div>
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-27 makeStyles-tableCellRoot-36 MuiTableCell-head"
+            class="MuiTableCell-root makeStyles-tableCellRoot-29 makeStyles-tableCellRoot-38 MuiTableCell-head"
             role="columnheader"
             scope="col"
             style="width: 100px;"
           >
             <p
-              class="MuiTypography-root makeStyles-typographyRoot-28 makeStyles-typographyRoot-37 MuiTypography-body1"
+              class="MuiTypography-root makeStyles-typographyRoot-30 makeStyles-typographyRoot-39 MuiTypography-body1"
             >
               Field A
             </p>
             <div
-              class="MuiGrid-root makeStyles-sortContainerRoot-25 MuiGrid-container"
+              class="MuiGrid-root makeStyles-sortContainerRoot-27 MuiGrid-container"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root makeStyles-sortIconRoot-26 makeStyles-sortIconRoot-35"
+                class="MuiSvgIcon-root makeStyles-sortIconRoot-28 makeStyles-sortIconRoot-37"
                 focusable="false"
                 role="button"
                 viewBox="9 3 5 15"
@@ -529,7 +529,7 @@ exports[`DataTable ACT_ET theme matches the snapshot 1`] = `
               </svg>
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root makeStyles-sortIconRoot-26 makeStyles-sortIconRoot-35"
+                class="MuiSvgIcon-root makeStyles-sortIconRoot-28 makeStyles-sortIconRoot-37"
                 focusable="false"
                 role="button"
                 viewBox="9 7 5 15"
@@ -541,22 +541,22 @@ exports[`DataTable ACT_ET theme matches the snapshot 1`] = `
             </div>
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-27 makeStyles-tableCellRoot-39 MuiTableCell-head"
+            class="MuiTableCell-root makeStyles-tableCellRoot-29 makeStyles-tableCellRoot-41 MuiTableCell-head"
             role="columnheader"
             scope="col"
             style="width: 100px;"
           >
             <p
-              class="MuiTypography-root makeStyles-typographyRoot-28 makeStyles-typographyRoot-40 MuiTypography-body1"
+              class="MuiTypography-root makeStyles-typographyRoot-30 makeStyles-typographyRoot-42 MuiTypography-body1"
             >
               Field B
             </p>
             <div
-              class="MuiGrid-root makeStyles-sortContainerRoot-25 MuiGrid-container"
+              class="MuiGrid-root makeStyles-sortContainerRoot-27 MuiGrid-container"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root makeStyles-sortIconRoot-26 makeStyles-sortIconRoot-38"
+                class="MuiSvgIcon-root makeStyles-sortIconRoot-28 makeStyles-sortIconRoot-40"
                 focusable="false"
                 role="button"
                 viewBox="9 3 5 15"
@@ -567,7 +567,7 @@ exports[`DataTable ACT_ET theme matches the snapshot 1`] = `
               </svg>
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root makeStyles-sortIconRoot-26 makeStyles-sortIconRoot-38"
+                class="MuiSvgIcon-root makeStyles-sortIconRoot-28 makeStyles-sortIconRoot-40"
                 focusable="false"
                 role="button"
                 viewBox="9 7 5 15"
@@ -579,22 +579,22 @@ exports[`DataTable ACT_ET theme matches the snapshot 1`] = `
             </div>
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-27 makeStyles-tableCellRoot-42 MuiTableCell-head"
+            class="MuiTableCell-root makeStyles-tableCellRoot-29 makeStyles-tableCellRoot-44 MuiTableCell-head"
             role="columnheader"
             scope="col"
             style="width: 100px;"
           >
             <p
-              class="MuiTypography-root makeStyles-typographyRoot-28 makeStyles-typographyRoot-43 MuiTypography-body1"
+              class="MuiTypography-root makeStyles-typographyRoot-30 makeStyles-typographyRoot-45 MuiTypography-body1"
             >
               Field C
             </p>
             <div
-              class="MuiGrid-root makeStyles-sortContainerRoot-25 MuiGrid-container"
+              class="MuiGrid-root makeStyles-sortContainerRoot-27 MuiGrid-container"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root makeStyles-sortIconRoot-26 makeStyles-sortIconRoot-41"
+                class="MuiSvgIcon-root makeStyles-sortIconRoot-28 makeStyles-sortIconRoot-43"
                 focusable="false"
                 role="button"
                 viewBox="9 3 5 15"
@@ -605,7 +605,7 @@ exports[`DataTable ACT_ET theme matches the snapshot 1`] = `
               </svg>
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root makeStyles-sortIconRoot-26 makeStyles-sortIconRoot-41"
+                class="MuiSvgIcon-root makeStyles-sortIconRoot-28 makeStyles-sortIconRoot-43"
                 focusable="false"
                 role="button"
                 viewBox="9 7 5 15"
@@ -625,35 +625,35 @@ exports[`DataTable ACT_ET theme matches the snapshot 1`] = `
           class="MuiTableRow-root MuiTableRow-hover"
         >
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-44 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-46 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 50px;"
           >
             1
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-44 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-46 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
             Item 1
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-44 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-46 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
             Field A1
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-44 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-46 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
             Field B1
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-44 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-46 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
@@ -664,35 +664,35 @@ exports[`DataTable ACT_ET theme matches the snapshot 1`] = `
           class="MuiTableRow-root MuiTableRow-hover"
         >
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-44 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-46 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 50px;"
           >
             2
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-44 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-46 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
             Item 2
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-44 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-46 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
             Field A2
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-44 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-46 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
             Field B2
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-44 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-46 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
@@ -703,35 +703,35 @@ exports[`DataTable ACT_ET theme matches the snapshot 1`] = `
           class="MuiTableRow-root MuiTableRow-hover"
         >
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-44 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-46 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 50px;"
           >
             3
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-44 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-46 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
             Item 3
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-44 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-46 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
             Field A3
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-44 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-46 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
             Field B3
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-44 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-46 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
@@ -742,35 +742,35 @@ exports[`DataTable ACT_ET theme matches the snapshot 1`] = `
           class="MuiTableRow-root MuiTableRow-hover"
         >
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-44 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-46 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 50px;"
           >
             4
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-44 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-46 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
             Item 4
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-44 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-46 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
             Field A4
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-44 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-46 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
             Field B4
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-44 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-46 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
@@ -781,35 +781,35 @@ exports[`DataTable ACT_ET theme matches the snapshot 1`] = `
           class="MuiTableRow-root MuiTableRow-hover"
         >
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-44 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-46 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 50px;"
           >
             5
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-44 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-46 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
             Item 5
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-44 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-46 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
             Field A5
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-44 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-46 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >
             Field B5
           </td>
           <td
-            class="MuiTableCell-root makeStyles-tableCellRoot-44 MuiTableCell-body MuiTableCell-paddingNone"
+            class="MuiTableCell-root makeStyles-tableCellRoot-46 MuiTableCell-body MuiTableCell-paddingNone"
             role="cell"
             style="width: 100px;"
           >

--- a/src/components/DataTable/index.stories.mdx
+++ b/src/components/DataTable/index.stories.mdx
@@ -30,6 +30,7 @@ component from Material UI.
     name="Color: Default"
     args={{
       color: 'default',
+      totalCount: 10,
     }}
   >
     {Template.bind({})}
@@ -43,6 +44,7 @@ component from Material UI.
     name="Color: Primary"
     args={{
       color: 'primary',
+      totalCount: 10,
     }}
   >
     {Template.bind({})}
@@ -56,6 +58,7 @@ component from Material UI.
     name="Color: Secondary"
     args={{
       color: 'secondary',
+      totalCount: 10,
     }}
   >
     {Template.bind({})}
@@ -80,6 +83,7 @@ component from Material UI.
           {children}
         </Link>
       ),
+      totalCount: 10,
     }}
   >
     {Template.bind({})}
@@ -96,7 +100,23 @@ component from Material UI.
         description: 'No Items Found',
         Icon: PackageVariant,
       },
-      items: [],
+      totalCount: 0,
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Paginated
+
+<Canvas>
+  <Story
+    name="Paginated"
+    args={{
+      limit: 10,
+      offset: 0,
+      rowsPerPageOptions: [10, 25, 50],
+      totalCount: 100,
     }}
   >
     {Template.bind({})}
@@ -107,7 +127,12 @@ component from Material UI.
 
 <Canvas isColumn>
   <Source language="jsx" story="Playground" />
-  <Story name="Playground" args={{}}>
+  <Story
+    name="Playground"
+    args={{
+      totalCount: 10,
+    }}
+  >
     {Template.bind({})}
   </Story>
   <ArgsTable story="Playground" />

--- a/src/components/DataTable/index.stories.template.tsx
+++ b/src/components/DataTable/index.stories.template.tsx
@@ -32,7 +32,7 @@ export const Template: Story<DataTableProps<Item>> = ({
   offset: offsetProps,
   totalCount,
   ...args
-}) => {
+}: DataTableProps<Item>) => {
   const [limit, setLimit] = React.useState<number | undefined>(limitProps);
   const [offset, setOffset] = React.useState<number | undefined>(offsetProps);
   const [sortObject, setSortObject] = React.useState<SortObject>({

--- a/src/components/DataTable/index.stories.template.tsx
+++ b/src/components/DataTable/index.stories.template.tsx
@@ -8,6 +8,7 @@
  */
 
 import * as React from 'react';
+import { isNumber } from 'lodash';
 import moment from 'moment';
 import { Story } from '@storybook/react/types-6-0';
 
@@ -26,13 +27,20 @@ interface Item {
   fieldC: string;
 }
 
-export const Template: Story<DataTableProps<Item>> = args => {
+export const Template: Story<DataTableProps<Item>> = ({
+  limit: limitProps,
+  offset: offsetProps,
+  totalCount,
+  ...args
+}) => {
+  const [limit, setLimit] = React.useState<number | undefined>(limitProps);
+  const [offset, setOffset] = React.useState<number | undefined>(offsetProps);
   const [sortObject, setSortObject] = React.useState<SortObject>({
     sortBy: 'id',
     sortDirection: SORT_DIRECTION_TYPES.ASCENDING,
   });
 
-  let items: Item[] = [...Array(10)].map((_, i): any => ({
+  let items: Item[] = [...Array(totalCount || 0)].map((_, i): any => ({
     updatedAt: moment()
       .subtract(2, 'year')
       .subtract(i + 1, 'day')
@@ -43,6 +51,10 @@ export const Template: Story<DataTableProps<Item>> = args => {
     id: i + 1,
     name: `Item ${i + 1}`,
   }));
+
+  if (isNumber(limit) && isNumber(offset)) {
+    items = items.slice(offset, offset + limit);
+  }
 
   // sort items
   items = items.sort(sort<Item>(sortObject));
@@ -102,9 +114,12 @@ export const Template: Story<DataTableProps<Item>> = args => {
       ]}
       currentSortObject={sortObject}
       items={items}
-      onChangeSort={(newSortObject): void => {
-        setSortObject(newSortObject);
-      }}
+      limit={limit}
+      offset={offset}
+      onChangeLimit={setLimit}
+      onChangeOffset={setOffset}
+      onChangeSort={setSortObject}
+      totalCount={totalCount}
       {...args}
     />
   );

--- a/src/components/DataTable/index.tsx
+++ b/src/components/DataTable/index.tsx
@@ -8,6 +8,7 @@
  */
 
 import * as React from 'react';
+import { constant, isNumber, round } from 'lodash';
 import {
   Table,
   TableBody,

--- a/src/components/DataTable/index.tsx
+++ b/src/components/DataTable/index.tsx
@@ -8,10 +8,17 @@
  */
 
 import * as React from 'react';
-import { Table, TableBody, TableHead, TableRow } from '@material-ui/core';
+import {
+  Table,
+  TableBody,
+  TableHead,
+  TablePagination,
+  TableRow,
+} from '@material-ui/core';
 
 import { EmptyState, EmptyStateProps } from '~/components/EmptyState';
 import { SortObject } from '~/types';
+import TablePaginationActions from '~/components/TablePaginationActions';
 
 import TableCellBody from './TableCellBody';
 import TableCellHead from './TableCellHead';
@@ -32,11 +39,16 @@ export interface DataTableProps<T> {
   currentSortObject: SortObject;
   emptyStateProps?: EmptyStateProps;
   items: T[];
+  limit?: number;
+  offset?: number;
+  onChangeLimit?: (limit: number) => void;
+  onChangeOffset?: (offset: number) => void;
   onChangeSort: (sortObject: SortObject) => void;
   RowWrapper?: (
     item: T,
     children: React.ReactElement<any>,
   ) => React.ReactElement<any>;
+  totalCount?: number;
 }
 
 export const DataTable = <T,>({
@@ -45,8 +57,13 @@ export const DataTable = <T,>({
   currentSortObject,
   emptyStateProps,
   items,
+  limit,
+  offset,
+  onChangeLimit,
+  onChangeOffset,
   onChangeSort,
   RowWrapper,
+  totalCount,
 }: DataTableProps<T>): React.ReactElement<any> => {
   const classes = useStyles();
 
@@ -94,6 +111,34 @@ export const DataTable = <T,>({
 
             return children;
           })}
+
+          {items.length > 0 &&
+            isNumber(limit) &&
+            isNumber(offset) &&
+            isNumber(totalCount) && (
+              <TablePagination
+                ActionsComponent={TablePaginationActions as any}
+                classes={{
+                  root: classes.tablePaginationRoot,
+                }}
+                count={totalCount}
+                labelDisplayedRows={constant('')}
+                labelRowsPerPage="Rows Per Page:"
+                onPageChange={(_, zeroBasedPage: number): void => {
+                  if (onChangeOffset) {
+                    onChangeOffset(zeroBasedPage * limit);
+                  }
+                }}
+                onRowsPerPageChange={(e): void => {
+                  if (onChangeLimit) {
+                    onChangeLimit(Number(e.target.value));
+                  }
+                }}
+                page={round(offset / limit, 0)}
+                rowsPerPage={limit}
+                rowsPerPageOptions={[25, 50, 100]}
+              />
+            )}
         </TableBody>
       </Table>
 
@@ -108,7 +153,12 @@ export const DataTable = <T,>({
 
 DataTable.defaultProps = {
   color: 'default',
+  limit: undefined,
+  offset: undefined,
+  onChangeLimit: undefined,
+  onChangeOffset: undefined,
   RowWrapper: undefined,
+  totalCount: undefined,
 };
 
 export default DataTable;

--- a/src/components/DataTable/index.tsx
+++ b/src/components/DataTable/index.tsx
@@ -45,6 +45,7 @@ export interface DataTableProps<T> {
   onChangeLimit?: (limit: number) => void;
   onChangeOffset?: (offset: number) => void;
   onChangeSort: (sortObject: SortObject) => void;
+  rowsPerPageOptions?: number[];
   RowWrapper?: (
     item: T,
     children: React.ReactElement<any>,
@@ -63,6 +64,7 @@ export const DataTable = <T,>({
   onChangeLimit,
   onChangeOffset,
   onChangeSort,
+  rowsPerPageOptions,
   RowWrapper,
   totalCount,
 }: DataTableProps<T>): React.ReactElement<any> => {
@@ -134,10 +136,14 @@ export const DataTable = <T,>({
                   if (onChangeLimit) {
                     onChangeLimit(Number(e.target.value));
                   }
+
+                  if (onChangeOffset) {
+                    onChangeOffset(0);
+                  }
                 }}
                 page={round(offset / limit, 0)}
                 rowsPerPage={limit}
-                rowsPerPageOptions={[25, 50, 100]}
+                rowsPerPageOptions={rowsPerPageOptions || [25, 50, 100]}
               />
             )}
         </TableBody>
@@ -158,6 +164,7 @@ DataTable.defaultProps = {
   offset: undefined,
   onChangeLimit: undefined,
   onChangeOffset: undefined,
+  rowsPerPageOptions: undefined,
   RowWrapper: undefined,
   totalCount: undefined,
 };

--- a/src/components/DataTable/styles.ts
+++ b/src/components/DataTable/styles.ts
@@ -7,14 +7,19 @@
  * @prettier
  */
 
+import { grey } from '@material-ui/core/colors';
 import { makeStyles } from '@material-ui/core/styles';
 
-export default makeStyles(({ spacing }) => ({
+export default makeStyles(({ spacing, typography }) => ({
   emptyStateContainer: {
     paddingBottom: spacing(1),
     paddingLeft: spacing(1),
     paddingRight: spacing(1),
     paddingTop: spacing(1) * 2.5,
     width: '100%',
+  },
+  tablePaginationRoot: {
+    backgroundColor: grey[50],
+    fontSize: typography.body2.fontSize,
   },
 }));

--- a/src/components/TablePaginationActions/__snapshots__/index.test.tsx.snap
+++ b/src/components/TablePaginationActions/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,323 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TablePaginationActions ENTERPRISE theme matches the snapshot 1`] = `
+<div>
+  <div
+    class="makeStyles-container-8"
+  >
+    <span
+      class=""
+      title="First Page"
+    >
+      <button
+        aria-label="First Page"
+        class="MuiButtonBase-root MuiIconButton-root"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiIconButton-label"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M18.41,16.59L13.82,12L18.41,7.41L17,6L11,12L17,18L18.41,16.59M6,6H8V18H6V6Z"
+            />
+          </svg>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+    </span>
+    <span
+      class=""
+      title="Previous Page"
+    >
+      <button
+        aria-label="Previous Page"
+        class="MuiButtonBase-root MuiIconButton-root"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiIconButton-label"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M15.41,16.58L10.83,12L15.41,7.41L14,6L8,12L14,18L15.41,16.58Z"
+            />
+          </svg>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+    </span>
+    <div>
+      <div
+        class="MuiFormControl-root MuiTextField-root makeStyles-textFieldRoot-14"
+      >
+        <div
+          class="MuiInputBase-root MuiInput-root makeStyles-inputRoot-9 MuiInputBase-formControl MuiInput-formControl"
+        >
+          <div
+            aria-haspopup="listbox"
+            class="MuiSelect-root MuiSelect-select makeStyles-selectSelect-12 MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+            role="button"
+            tabindex="0"
+          >
+            <span>
+              Page 2
+            </span>
+          </div>
+          <input
+            aria-hidden="true"
+            class="MuiSelect-nativeInput"
+            tabindex="-1"
+            value="1"
+          />
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSelect-icon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M7 10l5 5 5-5z"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
+    <span
+      class=""
+      title="Next Page"
+    >
+      <button
+        aria-label="Next Page"
+        class="MuiButtonBase-root MuiIconButton-root"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiIconButton-label"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
+            />
+          </svg>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+    </span>
+    <span
+      class=""
+      title="Last Page"
+    >
+      <button
+        aria-label="Last Page"
+        class="MuiButtonBase-root MuiIconButton-root"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiIconButton-label"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M5.59,7.41L10.18,12L5.59,16.59L7,18L13,12L7,6L5.59,7.41M16,6H18V18H16V6Z"
+            />
+          </svg>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+    </span>
+  </div>
+</div>
+`;
+
+exports[`TablePaginationActions NOVA theme matches the snapshot 1`] = `
+<div>
+  <div
+    class="makeStyles-container-1"
+  >
+    <span
+      class=""
+      title="First Page"
+    >
+      <button
+        aria-label="First Page"
+        class="MuiButtonBase-root MuiIconButton-root"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiIconButton-label"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M18.41,16.59L13.82,12L18.41,7.41L17,6L11,12L17,18L18.41,16.59M6,6H8V18H6V6Z"
+            />
+          </svg>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+    </span>
+    <span
+      class=""
+      title="Previous Page"
+    >
+      <button
+        aria-label="Previous Page"
+        class="MuiButtonBase-root MuiIconButton-root"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiIconButton-label"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M15.41,16.58L10.83,12L15.41,7.41L14,6L8,12L14,18L15.41,16.58Z"
+            />
+          </svg>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+    </span>
+    <div>
+      <div
+        class="MuiFormControl-root MuiTextField-root makeStyles-textFieldRoot-7"
+      >
+        <div
+          class="MuiInputBase-root MuiInput-root makeStyles-inputRoot-2 MuiInputBase-formControl MuiInput-formControl"
+        >
+          <div
+            aria-haspopup="listbox"
+            class="MuiSelect-root MuiSelect-select makeStyles-selectSelect-5 MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+            role="button"
+            tabindex="0"
+          >
+            <span>
+              Page 2
+            </span>
+          </div>
+          <input
+            aria-hidden="true"
+            class="MuiSelect-nativeInput"
+            tabindex="-1"
+            value="1"
+          />
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSelect-icon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M7 10l5 5 5-5z"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
+    <span
+      class=""
+      title="Next Page"
+    >
+      <button
+        aria-label="Next Page"
+        class="MuiButtonBase-root MuiIconButton-root"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiIconButton-label"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
+            />
+          </svg>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+    </span>
+    <span
+      class=""
+      title="Last Page"
+    >
+      <button
+        aria-label="Last Page"
+        class="MuiButtonBase-root MuiIconButton-root"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiIconButton-label"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M5.59,7.41L10.18,12L5.59,16.59L7,18L13,12L7,6L5.59,7.41M16,6H18V18H16V6Z"
+            />
+          </svg>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+    </span>
+  </div>
+</div>
+`;

--- a/src/components/TablePaginationActions/__snapshots__/index.test.tsx.snap
+++ b/src/components/TablePaginationActions/__snapshots__/index.test.tsx.snap
@@ -1,6 +1,171 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TablePaginationActions ENTERPRISE theme matches the snapshot 1`] = `
+exports[`TablePaginationActions ACT theme matches the snapshot 1`] = `
+<div>
+  <div
+    class="makeStyles-container-1"
+  >
+    <span
+      class=""
+      color="primary"
+      title="First Page"
+    >
+      <button
+        aria-label="First Page"
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiIconButton-label"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M18.41,16.59L13.82,12L18.41,7.41L17,6L11,12L17,18L18.41,16.59M6,6H8V18H6V6Z"
+            />
+          </svg>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+    </span>
+    <span
+      class=""
+      color="primary"
+      title="Previous Page"
+    >
+      <button
+        aria-label="Previous Page"
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiIconButton-label"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M15.41,16.58L10.83,12L15.41,7.41L14,6L8,12L14,18L15.41,16.58Z"
+            />
+          </svg>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+    </span>
+    <div>
+      <div
+        class="MuiFormControl-root MuiTextField-root makeStyles-textFieldRoot-7"
+      >
+        <div
+          class="MuiInputBase-root MuiInput-root makeStyles-inputRoot-2 MuiInputBase-formControl MuiInput-formControl"
+        >
+          <div
+            aria-haspopup="listbox"
+            class="MuiSelect-root MuiSelect-select makeStyles-selectSelect-5 MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiInput-input"
+            role="button"
+            tabindex="0"
+          >
+            <span>
+              Page 2
+            </span>
+          </div>
+          <input
+            aria-hidden="true"
+            class="MuiSelect-nativeInput"
+            tabindex="-1"
+            value="1"
+          />
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSelect-icon MuiSelect-iconOutlined"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M7 10l5 5 5-5z"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
+    <span
+      class=""
+      color="primary"
+      title="Next Page"
+    >
+      <button
+        aria-label="Next Page"
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiIconButton-label"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
+            />
+          </svg>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+    </span>
+    <span
+      class=""
+      color="primary"
+      title="Last Page"
+    >
+      <button
+        aria-label="Last Page"
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiIconButton-label"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M5.59,7.41L10.18,12L5.59,16.59L7,18L13,12L7,6L5.59,7.41M16,6H18V18H16V6Z"
+            />
+          </svg>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+    </span>
+  </div>
+</div>
+`;
+
+exports[`TablePaginationActions ACT_ET theme matches the snapshot 1`] = `
 <div>
   <div
     class="makeStyles-container-8"
@@ -68,11 +233,11 @@ exports[`TablePaginationActions ENTERPRISE theme matches the snapshot 1`] = `
         class="MuiFormControl-root MuiTextField-root makeStyles-textFieldRoot-14"
       >
         <div
-          class="MuiInputBase-root MuiInput-root makeStyles-inputRoot-9 MuiInputBase-formControl MuiInput-formControl"
+          class="MuiInputBase-root MuiOutlinedInput-root makeStyles-inputRoot-9 MuiInputBase-formControl MuiInputBase-marginDense MuiOutlinedInput-marginDense"
         >
           <div
             aria-haspopup="listbox"
-            class="MuiSelect-root MuiSelect-select makeStyles-selectSelect-12 MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+            class="MuiSelect-root MuiSelect-select makeStyles-selectSelect-12 MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
             role="button"
             tabindex="0"
           >
@@ -88,7 +253,7 @@ exports[`TablePaginationActions ENTERPRISE theme matches the snapshot 1`] = `
           />
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSelect-icon"
+            class="MuiSvgIcon-root MuiSelect-icon MuiSelect-iconOutlined"
             focusable="false"
             viewBox="0 0 24 24"
           >
@@ -96,167 +261,20 @@ exports[`TablePaginationActions ENTERPRISE theme matches the snapshot 1`] = `
               d="M7 10l5 5 5-5z"
             />
           </svg>
-        </div>
-      </div>
-    </div>
-    <span
-      class=""
-      title="Next Page"
-    >
-      <button
-        aria-label="Next Page"
-        class="MuiButtonBase-root MuiIconButton-root"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          class="MuiIconButton-label"
-        >
-          <svg
+          <fieldset
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-            focusable="false"
-            viewBox="0 0 24 24"
+            class="PrivateNotchedOutline-root-15 MuiOutlinedInput-notchedOutline"
+            style="padding-left: 8px;"
           >
-            <path
-              d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
-            />
-          </svg>
-        </span>
-        <span
-          class="MuiTouchRipple-root"
-        />
-      </button>
-    </span>
-    <span
-      class=""
-      title="Last Page"
-    >
-      <button
-        aria-label="Last Page"
-        class="MuiButtonBase-root MuiIconButton-root"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          class="MuiIconButton-label"
-        >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M5.59,7.41L10.18,12L5.59,16.59L7,18L13,12L7,6L5.59,7.41M16,6H18V18H16V6Z"
-            />
-          </svg>
-        </span>
-        <span
-          class="MuiTouchRipple-root"
-        />
-      </button>
-    </span>
-  </div>
-</div>
-`;
-
-exports[`TablePaginationActions NOVA theme matches the snapshot 1`] = `
-<div>
-  <div
-    class="makeStyles-container-1"
-  >
-    <span
-      class=""
-      title="First Page"
-    >
-      <button
-        aria-label="First Page"
-        class="MuiButtonBase-root MuiIconButton-root"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          class="MuiIconButton-label"
-        >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M18.41,16.59L13.82,12L18.41,7.41L17,6L11,12L17,18L18.41,16.59M6,6H8V18H6V6Z"
-            />
-          </svg>
-        </span>
-        <span
-          class="MuiTouchRipple-root"
-        />
-      </button>
-    </span>
-    <span
-      class=""
-      title="Previous Page"
-    >
-      <button
-        aria-label="Previous Page"
-        class="MuiButtonBase-root MuiIconButton-root"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          class="MuiIconButton-label"
-        >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M15.41,16.58L10.83,12L15.41,7.41L14,6L8,12L14,18L15.41,16.58Z"
-            />
-          </svg>
-        </span>
-        <span
-          class="MuiTouchRipple-root"
-        />
-      </button>
-    </span>
-    <div>
-      <div
-        class="MuiFormControl-root MuiTextField-root makeStyles-textFieldRoot-7"
-      >
-        <div
-          class="MuiInputBase-root MuiInput-root makeStyles-inputRoot-2 MuiInputBase-formControl MuiInput-formControl"
-        >
-          <div
-            aria-haspopup="listbox"
-            class="MuiSelect-root MuiSelect-select makeStyles-selectSelect-5 MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
-            role="button"
-            tabindex="0"
-          >
-            <span>
-              Page 2
-            </span>
-          </div>
-          <input
-            aria-hidden="true"
-            class="MuiSelect-nativeInput"
-            tabindex="-1"
-            value="1"
-          />
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSelect-icon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M7 10l5 5 5-5z"
-            />
-          </svg>
+            <legend
+              class="PrivateNotchedOutline-legend-16"
+              style="width: 0.01px;"
+            >
+              <span>
+                ​
+              </span>
+            </legend>
+          </fieldset>
         </div>
       </div>
     </div>

--- a/src/components/TablePaginationActions/index.stories.mdx
+++ b/src/components/TablePaginationActions/index.stories.mdx
@@ -1,0 +1,114 @@
+<!-- @prettier -->
+
+import {
+  ArgsTable,
+  Canvas,
+  Description,
+  Meta,
+  Preview,
+  Source,
+  Story,
+} from '@storybook/addon-docs';
+
+import { Magnify } from '~/icons';
+
+import { argTypes, Template } from './index.stories.template';
+import { TablePaginationActions, TablePaginationActionsProps } from '.';
+
+<Meta
+  title="Molecules/TablePaginationActions"
+  component={TablePaginationActions}
+  argTypes={argTypes}
+/>
+
+<Description of={TablePaginationActions} />
+
+## Standard
+
+<Canvas>
+  <Story
+    name="Standard"
+    args={{
+      count: 100,
+      rowsPerPage: 25,
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Disabled
+
+<Canvas>
+  <Story
+    name="Disabled"
+    args={{
+      count: 100,
+      disabled: true,
+      rowsPerPage: 25,
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Custom Noun
+
+<Canvas>
+  <Story
+    name="Custom Noun"
+    args={{
+      count: 100,
+      noun: 'Thing',
+      rowsPerPage: 25,
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Custom Tooltip Placement
+
+<Canvas>
+  <Story
+    name="Custom Tooltip Placement"
+    args={{
+      count: 100,
+      rowsPerPage: 25,
+      tooltipPlacement: 'top',
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Variant: Inverted
+
+<Canvas>
+  <Story
+    name="Variant: Inverted"
+    args={{
+      count: 100,
+      rowsPerPage: 25,
+      variant: 'inverted',
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Playground
+
+<Canvas isColumn>
+  <Source language="jsx" story="Playground" />
+  <Story
+    name="Playground"
+    args={{
+      count: 100,
+      rowsPerPage: 25,
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+  <ArgsTable story="Playground" />
+</Canvas>

--- a/src/components/TablePaginationActions/index.stories.template.tsx
+++ b/src/components/TablePaginationActions/index.stories.template.tsx
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) ACT, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @prettier
+ */
+
+import * as React from 'react';
+import { Story } from '@storybook/react/types-6-0';
+
+import { TablePaginationActions, TablePaginationActionsProps } from '.';
+import { Playground } from '~/helpers/playground';
+
+export const Template: Story<TablePaginationActionsProps> = args => {
+  const [page, setPage] = React.useState(0);
+
+  return (
+    <TablePaginationActions<Thing>
+      onPageChange={(_, p): void => {
+        setPage(p);
+      }}
+      page={page}
+      {...args}
+    />
+  );
+};
+Template.args = {};
+
+export const argTypes = Playground(
+  {
+    count: {},
+    disabled: {},
+    noun: {},
+    onPageChange: {},
+    page: {},
+    rowsPerPage: {},
+    tooltipPlacement: {},
+    variant: {},
+  },
+  TablePaginationActions,
+);

--- a/src/components/TablePaginationActions/index.test.tsx
+++ b/src/components/TablePaginationActions/index.test.tsx
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) ACT, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @prettier
+ */
+
+import * as React from 'react';
+import { noop } from 'lodash';
+
+import { standard } from '~/helpers/test';
+
+import TablePaginationActions from '.';
+
+describe('TablePaginationActions', () => {
+  const Component = (
+    <TablePaginationActions
+      count={1000}
+      onPageChange={noop}
+      page={1}
+      rowsPerPage={100}
+    />
+  );
+
+  standard(Component);
+});

--- a/src/components/TablePaginationActions/index.tsx
+++ b/src/components/TablePaginationActions/index.tsx
@@ -1,0 +1,255 @@
+/**
+ * Copyright (c) ACT, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @prettier
+ */
+
+import * as React from 'react';
+import clsx from 'clsx';
+import { FixedSizeList } from 'react-window';
+import { grey } from '@material-ui/core/colors';
+import {
+  IconButton,
+  MenuItem,
+  PopperProps,
+  TextField,
+  Tooltip,
+} from '@material-ui/core';
+import { min } from 'lodash';
+
+import { ChevronLeft, ChevronRight, PageFirst, PageLast } from '~/icons';
+
+import useStyles from './styles';
+
+export interface TablePaginationActionsProps {
+  count: number;
+  disabled?: boolean;
+  noun?: string;
+  onPageChange: (event: any, page: number) => void;
+  page: number;
+  PopperProps?: Partial<PopperProps>;
+  rowsPerPage: number;
+  style?: React.CSSProperties;
+  tooltipPlacement?:
+    | 'bottom'
+    | 'left'
+    | 'right'
+    | 'top'
+    | 'bottom-end'
+    | 'bottom-start'
+    | 'left-end'
+    | 'left-start'
+    | 'right-end'
+    | 'right-start'
+    | 'top-end'
+    | 'top-start';
+  variant?: 'inverted';
+}
+
+export const TablePaginationActions: React.FC<TablePaginationActionsProps> = ({
+  count,
+  disabled,
+  noun,
+  onPageChange,
+  page: zeroBasedPage,
+  PopperProps: PP,
+  rowsPerPage,
+  style,
+  tooltipPlacement,
+  variant,
+}: TablePaginationActionsProps): React.ReactElement<any> => {
+  const [open, setOpen] = React.useState(false);
+
+  const listEl = React.useRef(null);
+
+  const classes = useStyles();
+
+  const numberOfPages = Math.ceil(count / rowsPerPage);
+
+  const htmlColor = variant === 'inverted' ? grey[200] : undefined;
+  const htmlColorDisabled = variant === 'inverted' ? grey[700] : undefined;
+
+  const disableFirst = disabled || zeroBasedPage === 0;
+  const disablePrevious = disabled || zeroBasedPage === 0;
+  const disableNext =
+    disabled || zeroBasedPage >= Math.ceil(count / rowsPerPage) - 1;
+  const disableLast =
+    disabled || zeroBasedPage >= Math.ceil(count / rowsPerPage) - 1;
+
+  return (
+    <div className={classes.container} style={style}>
+      <Tooltip
+        arrow
+        placement={tooltipPlacement}
+        PopperProps={PP}
+        title={`First ${noun}`}
+      >
+        <span>
+          <IconButton
+            aria-label={`First ${noun}`}
+            disabled={disableFirst}
+            onClick={(event): void => onPageChange(event, 0)}
+          >
+            <PageFirst
+              fontSize="small"
+              htmlColor={disableFirst ? htmlColorDisabled : htmlColor}
+            />
+          </IconButton>
+        </span>
+      </Tooltip>
+
+      <Tooltip
+        arrow
+        placement={tooltipPlacement}
+        PopperProps={PP}
+        title={`Previous ${noun}`}
+      >
+        <span>
+          <IconButton
+            aria-label={`Previous ${noun}`}
+            disabled={disablePrevious}
+            onClick={(event): void => onPageChange(event, zeroBasedPage - 1)}
+          >
+            <ChevronLeft
+              fontSize="small"
+              htmlColor={disablePrevious ? htmlColorDisabled : htmlColor}
+            />
+          </IconButton>
+        </span>
+      </Tooltip>
+
+      <div>
+        <TextField
+          classes={{
+            root: classes.textFieldRoot,
+          }}
+          disabled={disabled}
+          InputProps={{
+            classes: {
+              root: classes.inputRoot,
+            },
+            disableUnderline: true,
+          }}
+          select
+          SelectProps={{
+            classes: {
+              icon: variant === 'inverted' ? classes.selectIconRoot : undefined,
+              select: clsx(
+                classes.selectSelect,
+                variant === 'inverted' && classes.selectSelectInverted,
+              ),
+            },
+            MenuProps: PP as any,
+            onClose: (): void => {
+              setOpen(false);
+            },
+            onOpen: (): void => {
+              setOpen(true);
+              setTimeout((): void => {
+                if (listEl) {
+                  (listEl as any).current.scrollToItem(
+                    Number(zeroBasedPage),
+                    'center',
+                  );
+                }
+              }, 10);
+            },
+            open,
+            // eslint-disable-next-line react/display-name
+            renderValue: (value): React.ReactElement<any> => (
+              <span>{`${noun} ${Number(value) + 1}`}</span>
+            ),
+          }}
+          value={zeroBasedPage}
+        >
+          <FixedSizeList
+            height={min([46 * numberOfPages, 300]) as number}
+            itemCount={numberOfPages}
+            itemSize={46}
+            ref={listEl}
+            width={`${noun} ${numberOfPages}`.length * 14}
+          >
+            {({ index, style: menuItemStyle }): React.ReactElement<any> => (
+              // eslint-disable-next-line react/no-array-index-key
+              <MenuItem
+                classes={{
+                  root: clsx(
+                    zeroBasedPage === index && classes.menuItemRootSelected,
+                  ),
+                }}
+                key={index}
+                onMouseDown={(event): void => {
+                  onPageChange(event, index);
+                  setOpen(false);
+                }}
+                style={menuItemStyle}
+                value={index}
+              >
+                {`${noun} ${index + 1}`}
+              </MenuItem>
+            )}
+          </FixedSizeList>
+        </TextField>
+      </div>
+
+      <Tooltip
+        arrow
+        placement={tooltipPlacement}
+        PopperProps={PP}
+        title={`Next ${noun}`}
+      >
+        <span>
+          <IconButton
+            aria-label={`Next ${noun}`}
+            disabled={disableNext}
+            onClick={(event): void => onPageChange(event, zeroBasedPage + 1)}
+          >
+            <ChevronRight
+              fontSize="small"
+              htmlColor={disableNext ? htmlColorDisabled : htmlColor}
+            />
+          </IconButton>
+        </span>
+      </Tooltip>
+
+      <Tooltip
+        arrow
+        placement={tooltipPlacement}
+        PopperProps={PP}
+        title={`Last ${noun}`}
+      >
+        <span>
+          <IconButton
+            aria-label={`Last ${noun}`}
+            disabled={disableLast}
+            onClick={(event): void => {
+              onPageChange(
+                event,
+                Math.max(0, Math.ceil(count / rowsPerPage) - 1),
+              );
+            }}
+          >
+            <PageLast
+              fontSize="small"
+              htmlColor={disableLast ? htmlColorDisabled : htmlColor}
+            />
+          </IconButton>
+        </span>
+      </Tooltip>
+    </div>
+  );
+};
+
+TablePaginationActions.defaultProps = {
+  disabled: false,
+  noun: 'Page',
+  PopperProps: undefined,
+  style: undefined,
+  tooltipPlacement: undefined,
+  variant: undefined,
+};
+
+export default TablePaginationActions;

--- a/src/components/TablePaginationActions/styles.ts
+++ b/src/components/TablePaginationActions/styles.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) ACT, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @prettier
+ */
+
+import { grey } from '@material-ui/core/colors';
+import { makeStyles } from '@material-ui/core/styles';
+
+export default makeStyles(({ palette }) => ({
+  container: {
+    alignItems: 'center',
+    display: 'inline-flex',
+    flexDirection: 'row',
+    justifyContent: 'center',
+    userSelect: 'none',
+  },
+  inputRoot: {
+    color: palette.text.primary,
+    fontSize: 14,
+  },
+  menuItemRootSelected: {
+    backgroundColor: grey[200],
+  },
+  selectIconRoot: {
+    color: grey[200],
+  },
+  selectSelect: {
+    paddingLeft: 8,
+    paddingRight: 24,
+    textAlign: 'right',
+    textAlignLast: 'right',
+  },
+  selectSelectInverted: {
+    color: grey[200],
+  },
+  textFieldRoot: {
+    margin: 0,
+  },
+}));

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -22,6 +22,7 @@ export * from './SearchBar';
 export * from './SessionStorageKeySharer';
 export * from './SessionTimer';
 export * from './SnackbarAlert';
+export * from './TablePaginationActions';
 export * from './ThemeProvider';
 
 // WIP COMPONENTS --------------------------------------------------------------


### PR DESCRIPTION
Enhanced `<DataTable />` component with optional props to support server-side pagination:

```ts
limit?: number;
offset?: number;
onChangeLimit?: (limit: number) => void;
onChangeOffset?: (offset: number) => void;
rowsPerPageOptions?: number[];
totalCount?: number;
```

Under the hood, the pagination UI has been abstracted into a re-usable component called `<TablePaginationActions />`.

Demo:

![2021-12-06 14 33 47](https://user-images.githubusercontent.com/4974609/144902636-e871eb50-9c15-490c-b744-4889295df0d6.gif)

