### PR TITLE
[v5.12.0]: Improved `<EmptyState />` UX across all themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Chronological history of changes to the Design Language System.
 
+## [v5.12.0] - Mar 09, 2022
+
+* Added new optional props to the `EmptyState` component
+  * `descriptionTypographyProps`
+  * `iconProps`
+  * `titleTypographyProps`
+* Improved the styling of the `EmptyState` title so that this component
+looks good across all themes.
+
 ## [v5.11.1] - Feb 28, 2022
 
 * Upgraded most of the NPM dependencies and dev-dependencies to their latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actinc/dls",
-  "version": "5.11.2",
+  "version": "5.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@actinc/dls",
-      "version": "5.11.1",
+      "version": "5.12.0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.17.2",

--- a/package.json
+++ b/package.json
@@ -148,5 +148,5 @@
     "test:unit": "jest --maxWorkers=2 --verbose"
   },
   "types": "index.d.ts",
-  "version": "5.11.1"
+  "version": "5.12.0"
 }

--- a/src/components/EmptyState/__snapshots__/index.test.tsx.snap
+++ b/src/components/EmptyState/__snapshots__/index.test.tsx.snap
@@ -12,14 +12,14 @@ exports[`EmptyState ACT theme matches the snapshot 1`] = `
         class="MuiGrid-root MuiGrid-item makeStyles-titleGridItem-8"
       >
         <h6
-          class="MuiTypography-root MuiTypography-h6 MuiTypography-alignCenter"
+          class="MuiTypography-root makeStyles-titleRoot-9 MuiTypography-body1 MuiTypography-alignCenter"
         >
           Title
         </h6>
       </div>
     </div>
     <p
-      class="MuiTypography-root makeStyles-descriptionRoot-2 MuiTypography-body1 MuiTypography-alignCenter"
+      class="MuiTypography-root makeStyles-descriptionRoot-2 MuiTypography-body1 MuiTypography-colorTextSecondary MuiTypography-alignCenter"
     >
       Description
     </p>
@@ -44,23 +44,23 @@ exports[`EmptyState ACT theme matches the snapshot 1`] = `
 exports[`EmptyState ACT_ET theme matches the snapshot 1`] = `
 <div>
   <div
-    class="makeStyles-container-9"
+    class="makeStyles-container-10"
   >
     <div
-      class="MuiGrid-root MuiGrid-container makeStyles-titleGridContainer-14 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-center"
+      class="MuiGrid-root MuiGrid-container makeStyles-titleGridContainer-15 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-center"
     >
       <div
-        class="MuiGrid-root MuiGrid-item makeStyles-titleGridItem-16"
+        class="MuiGrid-root MuiGrid-item makeStyles-titleGridItem-17"
       >
         <h6
-          class="MuiTypography-root MuiTypography-h6 MuiTypography-alignCenter"
+          class="MuiTypography-root makeStyles-titleRoot-18 MuiTypography-body1 MuiTypography-alignCenter"
         >
           Title
         </h6>
       </div>
     </div>
     <p
-      class="MuiTypography-root makeStyles-descriptionRoot-10 MuiTypography-body1 MuiTypography-alignCenter"
+      class="MuiTypography-root makeStyles-descriptionRoot-11 MuiTypography-body1 MuiTypography-colorTextSecondary MuiTypography-alignCenter"
     >
       Description
     </p>
@@ -85,23 +85,23 @@ exports[`EmptyState ACT_ET theme matches the snapshot 1`] = `
 exports[`EmptyState ENCOURA_DATALAB theme matches the snapshot 1`] = `
 <div>
   <div
-    class="makeStyles-container-17"
+    class="makeStyles-container-19"
   >
     <div
-      class="MuiGrid-root MuiGrid-container makeStyles-titleGridContainer-22 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-center"
+      class="MuiGrid-root MuiGrid-container makeStyles-titleGridContainer-24 MuiGrid-align-items-xs-center MuiGrid-justify-content-xs-center"
     >
       <div
-        class="MuiGrid-root MuiGrid-item makeStyles-titleGridItem-24"
+        class="MuiGrid-root MuiGrid-item makeStyles-titleGridItem-26"
       >
         <h6
-          class="MuiTypography-root MuiTypography-h6 MuiTypography-alignCenter"
+          class="MuiTypography-root makeStyles-titleRoot-27 MuiTypography-body1 MuiTypography-alignCenter"
         >
           Title
         </h6>
       </div>
     </div>
     <p
-      class="MuiTypography-root makeStyles-descriptionRoot-18 MuiTypography-body1 MuiTypography-alignCenter"
+      class="MuiTypography-root makeStyles-descriptionRoot-20 MuiTypography-body1 MuiTypography-colorTextSecondary MuiTypography-alignCenter"
     >
       Description
     </p>

--- a/src/components/EmptyState/index.stories.mdx
+++ b/src/components/EmptyState/index.stories.mdx
@@ -34,6 +34,60 @@ import { EmptyState, EmptyStateProps } from '.';
   </Story>
 </Canvas>
 
+## Custom Title
+
+<Canvas>
+  <Story
+    name="Custom Title"
+    args={{
+      description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+      Icon: Account,
+      title: 'No users yet.',
+      titleTypographyProps: {
+        variant: 'h1',
+      },
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Custom Description
+
+<Canvas>
+  <Story
+    name="Custom Description"
+    args={{
+      description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+      descriptionTypographyProps: {
+        variant: 'h1',
+      },
+      Icon: Account,
+      title: 'No users yet.',
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Custom Icon
+
+<Canvas>
+  <Story
+    name="Custom Icon"
+    args={{
+      description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+      Icon: Account,
+      iconProps: {
+        color: 'error',
+      },
+      title: 'No users yet.',
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
 ## Playground
 
 <Canvas isColumn>

--- a/src/components/EmptyState/index.stories.mdx
+++ b/src/components/EmptyState/index.stories.mdx
@@ -44,7 +44,7 @@ import { EmptyState, EmptyStateProps } from '.';
       Icon: Account,
       title: 'No users yet.',
       titleTypographyProps: {
-        variant: 'h1',
+        color: 'primary',
       },
     }}
   >
@@ -60,7 +60,7 @@ import { EmptyState, EmptyStateProps } from '.';
     args={{
       description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
       descriptionTypographyProps: {
-        variant: 'h1',
+        color: 'primary',
       },
       Icon: Account,
       title: 'No users yet.',

--- a/src/components/EmptyState/index.tsx
+++ b/src/components/EmptyState/index.tsx
@@ -72,7 +72,14 @@ export function EmptyState({
             }}
             item
           >
-            <Typography align="center" variant="h6" {...titleTypographyProps}>
+            <Typography
+              align="center"
+              classes={{
+                root: classes.titleRoot,
+              }}
+              variant="body1"
+              {...titleTypographyProps}
+            >
               {title}
             </Typography>
           </Grid>
@@ -88,6 +95,7 @@ export function EmptyState({
               !title && classes.descriptionRootWithoutTitle,
             ),
           }}
+          color="textSecondary"
           variant="body1"
           {...descriptionTypographyProps}
         >

--- a/src/components/EmptyState/index.tsx
+++ b/src/components/EmptyState/index.tsx
@@ -79,7 +79,7 @@ export function EmptyState({
               }}
               component="h6"
               variant="body1"
-              {...titleTypographyProps}
+              {...(titleTypographyProps as any)}
             >
               {title}
             </Typography>

--- a/src/components/EmptyState/index.tsx
+++ b/src/components/EmptyState/index.tsx
@@ -77,6 +77,7 @@ export function EmptyState({
               classes={{
                 root: classes.titleRoot,
               }}
+              component="h6"
               variant="body1"
               {...titleTypographyProps}
             >

--- a/src/components/EmptyState/index.tsx
+++ b/src/components/EmptyState/index.tsx
@@ -8,7 +8,14 @@
  */
 
 import * as React from 'react';
-import { Button, ButtonProps, Grid, Typography } from '@material-ui/core';
+import {
+  Button,
+  ButtonProps,
+  Grid,
+  IconProps,
+  Typography,
+  TypographyProps,
+} from '@material-ui/core';
 import clsx from 'clsx';
 import { isString } from 'lodash';
 
@@ -17,17 +24,23 @@ import useStyles from './styles';
 export interface EmptyStateProps {
   buttonProps?: ButtonProps;
   description?: any;
+  descriptionTypographyProps?: TypographyProps;
   Icon?: React.FC<any> | React.ComponentClass<any>;
+  iconProps?: IconProps;
   style?: React.CSSProperties;
   title?: string | React.ReactElement<unknown>;
+  titleTypographyProps?: TypographyProps;
 }
 
 export function EmptyState({
   buttonProps,
   description,
+  descriptionTypographyProps,
   Icon,
+  iconProps,
   style,
   title,
+  titleTypographyProps,
 }: EmptyStateProps): React.ReactElement<EmptyStateProps> {
   const classes = useStyles();
 
@@ -40,6 +53,7 @@ export function EmptyState({
           }}
           color="disabled"
           titleAccess={isString(title) ? title : undefined}
+          {...iconProps}
         />
       )}
 
@@ -58,7 +72,7 @@ export function EmptyState({
             }}
             item
           >
-            <Typography align="center" variant="h6">
+            <Typography align="center" variant="h6" {...titleTypographyProps}>
               {title}
             </Typography>
           </Grid>
@@ -75,6 +89,7 @@ export function EmptyState({
             ),
           }}
           variant="body1"
+          {...descriptionTypographyProps}
         >
           {description}
         </Typography>

--- a/src/components/EmptyState/styles.ts
+++ b/src/components/EmptyState/styles.ts
@@ -9,7 +9,7 @@
 
 import { makeStyles } from '@material-ui/core/styles';
 
-export default makeStyles(({ palette, spacing }) => ({
+export default makeStyles(({ spacing, typography }) => ({
   container: {
     alignItems: 'center',
     display: 'flex',
@@ -17,7 +17,6 @@ export default makeStyles(({ palette, spacing }) => ({
     flexDirection: 'column',
   },
   descriptionRoot: {
-    color: palette.text.secondary,
     marginBottom: spacing(2),
     marginTop: spacing(1) / 2,
     maxWidth: 350,
@@ -44,5 +43,11 @@ export default makeStyles(({ palette, spacing }) => ({
   },
   titleGridItem: {
     display: 'flex',
+  },
+  titleRoot: {
+    // Use one font weight higher than `body1` (varies from theme to theme)
+    fontWeight: Number(typography.body1.fontWeight) + 100,
+    // Scale the font to be 20% larger than `body1` (also varies from theme to theme)
+    transform: 'scale(1.2)',
   },
 }));


### PR DESCRIPTION
* Improved the styling of the `EmptyState` title so that this component looks good across all themes.
* Added new optional props to the `EmptyState` component
  * `descriptionTypographyProps`
  * `iconProps`
  * `titleTypographyProps`
* Added new stories to the storybook

---

Because the themes vary so wildly, this component didn't look as good on the `ACT` and `ENCOURA_DATALAB` themes as it did for `ACT_ET`. This is due to drastic differences in the `h6` font size across themes (the headings in general are all across the map!), as well as differences in the font weight used for `body1`.

Therefore, we are no longer using `h6` to determine the style of the title. Instead we are deriving the style from `body1`, which is much closer in style across the themes and is the variant that is used in the description.

This allows this component to look great across all themes:

`ACT`:

![Screen Shot 2022-03-09 at 4 45 29 PM](https://user-images.githubusercontent.com/4974609/157533490-cec7daa4-d3c7-4442-ac75-01d663620747.png)

`ACT_ET`:

![Screen Shot 2022-03-09 at 4 45 33 PM](https://user-images.githubusercontent.com/4974609/157533493-b67c594f-e18d-4e95-ae26-94c6a6a4837f.png)

`ENCOURA_DATALAB`:

![Screen Shot 2022-03-09 at 4 45 39 PM](https://user-images.githubusercontent.com/4974609/157533500-70455984-4342-4571-a798-f762b306f311.png)

