### PR TITLE
[v5.12.1]: Improved Prop Definition on `<EmptyState />`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Chronological history of changes to the Design Language System.
 
+## [v5.12.1] - Mar 09, 2022
+
+* Improved the TypeScript definition of the `titleTypographyProps` prop on 
+the `<EmptyState />` component.
+
 ## [v5.12.0] - Mar 09, 2022
 
 * Added new optional props to the `EmptyState` component

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Chronological history of changes to the Design Language System.
 
 ## [v5.12.1] - Mar 09, 2022
 
-* Improved the TypeScript definition of the `titleTypographyProps` prop on 
+* Improved the TypeScript definition of the `titleTypographyProps` prop on
 the `<EmptyState />` component.
 
 ## [v5.12.0] - Mar 09, 2022

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actinc/dls",
-  "version": "5.12.0",
+  "version": "5.12.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@actinc/dls",
-      "version": "5.12.0",
+      "version": "5.12.1",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.17.2",

--- a/package.json
+++ b/package.json
@@ -148,5 +148,5 @@
     "test:unit": "jest --maxWorkers=2 --verbose"
   },
   "types": "index.d.ts",
-  "version": "5.12.0"
+  "version": "5.12.1"
 }

--- a/package.json
+++ b/package.json
@@ -148,5 +148,5 @@
     "test:unit": "jest --maxWorkers=2 --verbose"
   },
   "types": "index.d.ts",
-  "version": "5.12.1"
+  "version": "5.12.0"
 }

--- a/src/components/EmptyState/index.tsx
+++ b/src/components/EmptyState/index.tsx
@@ -29,7 +29,9 @@ export interface EmptyStateProps {
   iconProps?: IconProps;
   style?: React.CSSProperties;
   title?: string | React.ReactElement<unknown>;
-  titleTypographyProps?: TypographyProps;
+  titleTypographyProps?: TypographyProps & {
+    component?: string;
+  };
 }
 
 export function EmptyState({
@@ -79,7 +81,7 @@ export function EmptyState({
               }}
               component="h6"
               variant="body1"
-              {...(titleTypographyProps as any)}
+              {...titleTypographyProps}
             >
               {title}
             </Typography>


### PR DESCRIPTION
Improved the TypeScript definition of the `titleTypographyProps` prop on the `<EmptyState />` component.