### PR TITLE
[v5.12.3]: More Peer Dep Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Chronological history of changes to the Design Language System.
 
-## [v5.12.2] - May 19, 2022
+## [v5.12.3] - May 19, 2022
 
 * Moved `@material-ui/core`, `@material-ui/data-grid`, and `@material-ui/lab`\
 to the `devDependencies` section of `package.json`, since they are peer

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ In order to use the DLS, you must install it along with
 [React](https://reactjs.org/) version `16.x` or `17.x`.
 
 ```shell
-npm install --save @actinc/dls@latest @material-ui/core@4 @material-ui/data-grid@4 @material-ui/lab@4 react@17 react-dom@17
+npm install --save @actinc/dls @material-ui/core @material-ui/data-grid @material-ui/lab react@17 react-dom@17
 ```
 
 ### Choosing a Theme

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actinc/dls",
-  "version": "5.12.2",
+  "version": "5.12.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@actinc/dls",
-      "version": "5.12.2",
+      "version": "5.12.3",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.17.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@babel/preset-react": "7.16.7",
         "@babel/preset-typescript": "7.16.7",
         "@material-ui/core": "4.12.1",
-        "@material-ui/data-grid": "^4.0.0-alpha.35",
+        "@material-ui/data-grid": "4.0.0-alpha.35",
         "@material-ui/lab": "4.0.0-alpha.60",
         "@storybook/addon-a11y": "6.4.19",
         "@storybook/addon-actions": "6.4.19",
@@ -86,8 +86,8 @@
       },
       "peerDependencies": {
         "@material-ui/core": "4.x",
-        "@material-ui/data-grid": "4.x",
-        "@material-ui/lab": "4.x",
+        "@material-ui/data-grid": "^4.0.0-alpha.35",
+        "@material-ui/lab": "^4.0.0-alpha.60",
         "react": "16.x || 17.x",
         "react-dom": "16.x || 17.x"
       }
@@ -4280,10 +4280,9 @@
       }
     },
     "node_modules/@material-ui/data-grid": {
-      "version": "4.0.0-alpha.37",
-      "resolved": "https://registry.npmjs.org/@material-ui/data-grid/-/data-grid-4.0.0-alpha.37.tgz",
-      "integrity": "sha512-3T2AG31aad/lWLMLwn1XUP4mUf3H9YZES17dGuYByzkRLCXbBZHBTPEnCctWukajzwm+v0KGg3QpwitGoiDAjA==",
-      "deprecated": "The name of the package has changed, more details in https://github.com/mui-org/material-ui-x/releases/tag/v4.0.0",
+      "version": "4.0.0-alpha.35",
+      "resolved": "https://registry.npmjs.org/@material-ui/data-grid/-/data-grid-4.0.0-alpha.35.tgz",
+      "integrity": "sha512-liyubO6MszF61Ceqx/yMGM0iWPVjg2+yf63m95qUSAp/Q1DyJenWP0XD78YZ1ZCqWbH1LIxJiuHEO+9iqKa7wA==",
       "dev": true,
       "dependencies": {
         "@material-ui/utils": "^5.0.0-alpha.14",
@@ -4295,8 +4294,7 @@
         "node": ">=12.0.0"
       },
       "peerDependencies": {
-        "@material-ui/core": "^4.12.0 || ^5.0.0-beta.0",
-        "@material-ui/styles": "^4.11.4 || ^5.0.0-beta.0",
+        "@material-ui/core": "^4.9.12 || ^5.0.0-beta.0",
         "react": "^17.0.0"
       }
     },
@@ -38893,9 +38891,9 @@
       }
     },
     "@material-ui/data-grid": {
-      "version": "4.0.0-alpha.37",
-      "resolved": "https://registry.npmjs.org/@material-ui/data-grid/-/data-grid-4.0.0-alpha.37.tgz",
-      "integrity": "sha512-3T2AG31aad/lWLMLwn1XUP4mUf3H9YZES17dGuYByzkRLCXbBZHBTPEnCctWukajzwm+v0KGg3QpwitGoiDAjA==",
+      "version": "4.0.0-alpha.35",
+      "resolved": "https://registry.npmjs.org/@material-ui/data-grid/-/data-grid-4.0.0-alpha.35.tgz",
+      "integrity": "sha512-liyubO6MszF61Ceqx/yMGM0iWPVjg2+yf63m95qUSAp/Q1DyJenWP0XD78YZ1ZCqWbH1LIxJiuHEO+9iqKa7wA==",
       "dev": true,
       "requires": {
         "@material-ui/utils": "^5.0.0-alpha.14",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@babel/preset-react": "7.16.7",
     "@babel/preset-typescript": "7.16.7",
     "@material-ui/core": "4.12.1",
-    "@material-ui/data-grid": "^4.0.0-alpha.35",
+    "@material-ui/data-grid": "4.0.0-alpha.35",
     "@material-ui/lab": "4.0.0-alpha.60",
     "@storybook/addon-a11y": "6.4.19",
     "@storybook/addon-actions": "6.4.19",
@@ -107,8 +107,8 @@
   "name": "@actinc/dls",
   "peerDependencies": {
     "@material-ui/core": "4.x",
-    "@material-ui/data-grid": "4.x",
-    "@material-ui/lab": "4.x",
+    "@material-ui/data-grid": "^4.0.0-alpha.35",
+    "@material-ui/lab": "^4.0.0-alpha.60",
     "react": "16.x || 17.x",
     "react-dom": "16.x || 17.x"
   },

--- a/package.json
+++ b/package.json
@@ -148,5 +148,5 @@
     "test:unit": "jest --maxWorkers=2 --verbose"
   },
   "types": "index.d.ts",
-  "version": "5.12.2"
+  "version": "5.12.3"
 }


### PR DESCRIPTION
Follow-on patch release for v5.12.2, since `@material-ui/data-grid` and `@material-ui/lab` don't use true semantic versioning.