### PR TITLE
More v7 Tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ import { createTheme } from '@actinc/dls/styles/createTheme';
 import { THEME_ACT } from '@actinc/dls/styles/themeAct';
 import { ThemeProvider } from '@actinc/dls/components';
 
-const myExtendedTheme = createTheme(deepMerge(THEME_ACT_ET, {
+const myExtendedTheme = createTheme(deepMerge(THEME_ACT, {
   // theme customizations go here!
 }));
 
@@ -102,7 +102,7 @@ present in the default MUI Theme type, then we provide a helper function to
 generate a styled function that is strongly typed to your theme:
 
 ```jsx
-import { createThemeStyled } from '@actinc/dls/helpers/material/styled';
+import { createThemeStyled } from '@actinc/dls/helpers/styled';
 import { THEME_ACT } from '@actinc/dls/styles/themeAct';
 import TableCell from '@mui/material/TableCell';
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,24 @@ const StyledTypography = styled(TableCell)(({ theme}) => ({
 }))
 ```
 
+### Next.js >= 13
+
+If your project is using Next.js > 13, you may see the following error
+on startup:
+
+```sh
+SyntaxError: Unexpected token 'export'
+```
+
+This is due to the DLS being built using ES Modules as opposed to CommonJS.
+To fix this issue in your project, try adding...
+
+```js
+transpilePackages: ['@actinc/dls'],
+```
+
+... to your `next.config.js` file.
+
 ### Load Fonts
 
 #### Montserrat

--- a/README.md
+++ b/README.md
@@ -124,13 +124,13 @@ SyntaxError: Unexpected token 'export'
 ```
 
 This is due to the DLS being built using ES Modules as opposed to CommonJS.
-To fix this issue in your project, try adding...
+To fix this issue in your project, try adding the DLS to the
+[`transpilePackages`](https://beta.nextjs.org/docs/api-reference/next.config.js#transpilepackages)
+option in your `next.config.js` file.
 
 ```js
 transpilePackages: ['@actinc/dls'],
 ```
-
-... to your `next.config.js` file.
 
 ### Load Fonts
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -26,7 +26,6 @@ export * from './GridGenerator';
 export * from './IdleTimer';
 export * from './InputLabel';
 export * from './Loading';
-// WIP COMPONENTS --------------------------------------------------------------
 export * from './RenderMetaTags';
 export * from './SearchBar';
 export * from './SessionStorageKeySharer';
@@ -34,3 +33,5 @@ export * from './SessionTimer';
 export * from './SnackbarAlert';
 export * from './TablePaginationActions';
 export * from './ThemeProvider';
+
+// WIP COMPONENTS --------------------------------------------------------------

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -7,6 +7,7 @@
  * @prettier
  */
 
+export * from './cssRadius';
 export * from './getErrorMessage';
 export * from './makeShadow';
 export * from './mergeClasses';
@@ -15,4 +16,5 @@ export * from './px';
 export * from './pxToNumber';
 export * from './search';
 export * from './sort';
+export * from './styled';
 export * from './types';

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -17,4 +17,5 @@ export * from './pxToNumber';
 export * from './search';
 export * from './sort';
 export * from './styled';
+export * from './test';
 export * from './types';

--- a/src/helpers/test/accessibility.ts
+++ b/src/helpers/test/accessibility.ts
@@ -7,6 +7,8 @@
  * @prettier
  */
 
+/* eslint-disable jest/no-export */
+
 import { configure, RenderOptions } from '@testing-library/react';
 import { axe, JestAxeConfigureOptions, toHaveNoViolations } from 'jest-axe';
 import { ReactElement } from 'react';
@@ -15,12 +17,12 @@ import render from './render';
 import THEMES from './themes';
 
 expect.extend(toHaveNoViolations);
-// eslint-disable-next-line jest/no-export
-export default function accessibility(
+
+export const accessibility = (
   Component: ReactElement,
   renderOptions?: RenderOptions,
   axeOptions?: JestAxeConfigureOptions,
-): void {
+): void => {
   configure({
     computedStyleSupportsPseudoElements: false,
   });
@@ -31,4 +33,6 @@ export default function accessibility(
       expect(await axe(container, axeOptions)).toHaveNoViolations();
     },
   );
-}
+};
+
+export default accessibility;

--- a/src/helpers/test/index.ts
+++ b/src/helpers/test/index.ts
@@ -7,8 +7,7 @@
  * @prettier
  */
 
-export { default as render } from './render';
-export { default as THEMES } from './themes';
-export { default as snapshot } from './snapshot';
-export { default as accessibility } from './accessibility';
-export { default as standard } from './standard';
+export * from './accessibility';
+export * from './render';
+export * from './snapshot';
+export * from './standard';

--- a/src/helpers/test/render.tsx
+++ b/src/helpers/test/render.tsx
@@ -34,4 +34,5 @@ export const render = (
     ),
     ...options,
   });
+
 export default render;

--- a/src/helpers/test/snapshot.ts
+++ b/src/helpers/test/snapshot.ts
@@ -7,19 +7,22 @@
  * @prettier
  */
 
+/* eslint-disable jest/no-export */
+
 import { RenderOptions } from '@testing-library/react';
 import { ReactElement } from 'react';
 
 import render from './render';
 import THEMES from './themes';
 
-// eslint-disable-next-line jest/no-export
-export default function snapshot(
+export const snapshot = (
   Component: ReactElement,
   renderOptions?: RenderOptions,
-): void {
+): void => {
   test.each(THEMES)('%s theme matches the snapshot', theme => {
     const { container } = render(Component, theme, renderOptions);
     expect(container).toMatchSnapshot();
   });
-}
+};
+
+export default snapshot;

--- a/src/helpers/test/standard.ts
+++ b/src/helpers/test/standard.ts
@@ -14,11 +14,13 @@ import { ReactElement } from 'react';
 import accessibility from './accessibility';
 import snapshot from './snapshot';
 
-export default function standard(
+export const standard = (
   Component: ReactElement,
   renderOptions?: RenderOptions,
   runOptions?: JestAxeConfigureOptions,
-): void {
+): void => {
   snapshot(Component, renderOptions);
   accessibility(Component, renderOptions, runOptions);
-}
+};
+
+export default standard;

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -10,4 +10,4 @@
 /* eslint-disable import/prefer-default-export */
 
 export * from './useConfirm';
-export { default as useLocalStorage } from './useLocalStorage';
+export * from './useLocalStorage';

--- a/src/hooks/useLocalStorage.tsx
+++ b/src/hooks/useLocalStorage.tsx
@@ -10,7 +10,7 @@
 import { isFunction } from 'lodash';
 import { useEffect, useState } from 'react';
 
-const useLocalStorage = (
+export const useLocalStorage = (
   key: string,
   initValue = '',
 ): [string, (v: string) => void] => {

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -7,7 +7,7 @@
  * @prettier
  */
 
-export { createTheme } from './createTheme';
+export * from './createTheme';
 export { default as THEME_ACT } from './themeAct';
 export { default as THEME_ACT_ET } from './themeActEt';
 export { default as THEME_ENCOURA_CLASSIC } from './themeEncouraClassic';

--- a/src/styles/themeAct/index.ts
+++ b/src/styles/themeAct/index.ts
@@ -17,7 +17,7 @@ import SHAPE from './shape';
 import spacing, { SPACING_PX } from './spacing';
 import TYPOGRAPHY from './typography';
 
-type ThemeCustomizations = ICustomDims & {
+export type ThemeCustomizations = ICustomDims & {
   palette: CustomPaletteOptions;
   spacingPx: number;
 };

--- a/src/styles/themeActEt/index.ts
+++ b/src/styles/themeActEt/index.ts
@@ -17,7 +17,7 @@ import SHAPE from './shape';
 import spacing, { SPACING_PX } from './spacing';
 import TYPOGRAPHY from './typography';
 
-type ThemeCustomizations = ICustomDims & {
+export type ThemeCustomizations = ICustomDims & {
   palette: CustomPaletteOptions;
   spacingPx: number;
 };

--- a/src/styles/themeEncouraClassic/index.ts
+++ b/src/styles/themeEncouraClassic/index.ts
@@ -17,7 +17,7 @@ import SHAPE from './shape';
 import spacing, { SPACING_PX } from './spacing';
 import TYPOGRAPHY from './typography';
 
-type ThemeCustomizations = ICustomDims & {
+export type ThemeCustomizations = ICustomDims & {
   palette: CustomPaletteOptions;
   spacingPx: number;
 };

--- a/src/styles/themeEncourage/index.ts
+++ b/src/styles/themeEncourage/index.ts
@@ -24,7 +24,7 @@ import spacing, { SPACING_PX } from './spacing';
 import typography from './typography';
 import zIndex from './zIndex';
 
-type ThemeCustomizations = ICustomDims & {
+export type ThemeCustomizations = ICustomDims & {
   breakpoints: BreakpointsOptions & {
     values: BreakpointsOptions['values'] & { mobile: number };
   };


### PR DESCRIPTION
* Updated `README.md` with information about using v7 in Next.js 13 app, Jest test runner, etc.
* Export more DLS helpers and utilities at the `index.js` levels
* Export the `ThemeCustomizations` type from each theme file (could be useful downstream)