### PR TITLE
Encourage - fix: Fixes font weight overriding preexisting font weights

### DIFF
--- a/src/components/Loading/index.tsx
+++ b/src/components/Loading/index.tsx
@@ -23,7 +23,7 @@ export const Loading: FC<LoadingProps> = ({
   style,
   title,
 }: LoadingProps): ReactElement<LoadingProps> => (
-  <StyledContainer aria-label={title} data-testid="loading" style={style}>
+  <StyledContainer aria-label={title} data-chromatic="ignore" data-testid="loading" style={style}>
     <CircularProgress
       size={24}
       thickness={4.5}

--- a/src/styles/themeEncourage/typography.ts
+++ b/src/styles/themeEncourage/typography.ts
@@ -95,17 +95,14 @@ const typography: TypographyVariantsOptions = {
     lineHeight: '24px',
     [theme.breakpoints.up('xs')]: {
       fontSize: '16px',
-      fontWeight: 400,
       lineHeight: '24px',
     },
     [theme.breakpoints.up('sm')]: {
       fontSize: '16px',
-      fontWeight: 400,
       lineHeight: '24px',
     },
     [theme.breakpoints.up('lg')]: {
       fontSize: '16px',
-      fontWeight: 400,
       lineHeight: '24px',
     },
   },
@@ -120,17 +117,14 @@ const typography: TypographyVariantsOptions = {
     lineHeight: '20px',
     [theme.breakpoints.up('xs')]: {
       fontSize: '14px',
-      fontWeight: 400,
       lineHeight: '20px',
     },
     [theme.breakpoints.up('sm')]: {
       fontSize: '14px',
-      fontWeight: 400,
       lineHeight: '20px',
     },
     [theme.breakpoints.up('lg')]: {
       fontSize: '14px',
-      fontWeight: 400,
       lineHeight: '20px',
     },
   },
@@ -180,17 +174,14 @@ const typography: TypographyVariantsOptions = {
     lineHeight: '32px',
     [theme.breakpoints.up('xs')]: {
       fontSize: '28px',
-      fontWeight: 500,
       lineHeight: '32px',
     },
     [theme.breakpoints.up('sm')]: {
       fontSize: '40px',
-      fontWeight: 600,
       lineHeight: '48px',
     },
     [theme.breakpoints.up('lg')]: {
       fontSize: '40px',
-      fontWeight: 600,
       lineHeight: '48px',
     },
   },
@@ -202,17 +193,14 @@ const typography: TypographyVariantsOptions = {
     lineHeight: '32px',
     [theme.breakpoints.up('xs')]: {
       fontSize: '24px',
-      fontWeight: 600,
       lineHeight: '32px',
     },
     [theme.breakpoints.up('sm')]: {
       fontSize: '32px',
-      fontWeight: 600,
       lineHeight: '40px',
     },
     [theme.breakpoints.up('lg')]: {
       fontSize: '32px',
-      fontWeight: 600,
       lineHeight: '40px',
     },
   },
@@ -224,17 +212,14 @@ const typography: TypographyVariantsOptions = {
     lineHeight: '24px',
     [theme.breakpoints.up('xs')]: {
       fontSize: '20px',
-      fontWeight: 600,
       lineHeight: '24px',
     },
     [theme.breakpoints.up('sm')]: {
       fontSize: '28px',
-      fontWeight: 600,
       lineHeight: '40px',
     },
     [theme.breakpoints.up('lg')]: {
       fontSize: '28px',
-      fontWeight: 600,
       lineHeight: '40px',
     },
   },
@@ -246,7 +231,6 @@ const typography: TypographyVariantsOptions = {
     lineHeight: '24px',
     [theme.breakpoints.up('lg')]: {
       fontSize: '24px',
-      fontWeight: 600,
       lineHeight: '32px',
     },
   },
@@ -258,17 +242,14 @@ const typography: TypographyVariantsOptions = {
     lineHeight: '24px',
     [theme.breakpoints.up('xs')]: {
       fontSize: '18px',
-      fontWeight: 500,
       lineHeight: '24px',
     },
     [theme.breakpoints.up('sm')]: {
       fontSize: '18px',
-      fontWeight: 600,
       lineHeight: '24px',
     },
     [theme.breakpoints.up('lg')]: {
       fontSize: '18px',
-      fontWeight: 600,
       lineHeight: '24px',
     },
   },
@@ -288,17 +269,14 @@ const typography: TypographyVariantsOptions = {
     textTransform: undefined, // Clear the base theme's transform
     [theme.breakpoints.up('xs')]: {
       fontSize: '18px',
-      fontWeight: 400,
       lineHeight: '24px',
     },
     [theme.breakpoints.up('sm')]: {
       fontSize: '18px',
-      fontWeight: 400,
       lineHeight: '24px',
     },
     [theme.breakpoints.up('lg')]: {
       fontSize: '18px',
-      fontWeight: 400,
       lineHeight: '24px',
     },
   },
@@ -310,17 +288,14 @@ const typography: TypographyVariantsOptions = {
     lineHeight: px(24),
     [theme.breakpoints.up('xs')]: {
       fontSize: '16px',
-      fontWeight: 400,
       lineHeight: '24px',
     },
     [theme.breakpoints.up('sm')]: {
       fontSize: '16px',
-      fontWeight: 400,
       lineHeight: '24px',
     },
     [theme.breakpoints.up('lg')]: {
       fontSize: '16px',
-      fontWeight: 400,
       lineHeight: '24px',
     },
   },

--- a/src/styles/themeEncourage/typography.ts
+++ b/src/styles/themeEncourage/typography.ts
@@ -178,10 +178,12 @@ const typography: TypographyVariantsOptions = {
     },
     [theme.breakpoints.up('sm')]: {
       fontSize: '40px',
+      fontWeight: 600,
       lineHeight: '48px',
     },
     [theme.breakpoints.up('lg')]: {
       fontSize: '40px',
+      fontWeight: 600,
       lineHeight: '48px',
     },
   },
@@ -246,10 +248,12 @@ const typography: TypographyVariantsOptions = {
     },
     [theme.breakpoints.up('sm')]: {
       fontSize: '18px',
+      fontWeight: 600,
       lineHeight: '24px',
     },
     [theme.breakpoints.up('lg')]: {
       fontSize: '18px',
+      fontWeight: 600,
       lineHeight: '24px',
     },
   },


### PR DESCRIPTION
Adding the font weight to the breakpoints makes it a more aggressive selection and overrides current font weights. This removes the font weights defined by the breakpoints.