### PR TITLE
chore: Updating h5 font size to proper value for small screens

### DIFF
--- a/src/styles/themeEncourage/typography.ts
+++ b/src/styles/themeEncourage/typography.ts
@@ -229,10 +229,10 @@ const typography: TypographyVariantsOptions = {
     fontFamily: primaryFontFamily,
     fontSize: '18px',
     fontWeight: 600,
-    letterSpacing: px(-0.75),
-    lineHeight: '24px',
-    [theme.breakpoints.up('lg')]: {
+    lineHeight: '22px',
+    [theme.breakpoints.up('sm')]: {
       fontSize: '24px',
+      letterSpacing: px(-0.75),
       lineHeight: '32px',
     },
   },


### PR DESCRIPTION
Updating `Encourage Theme` `h5` Typography variant to have `18px` font size for down('sm') and `24px` for up('sm')