### PR TITLE
feat: [IC-3915]: Remove customColors reference from new components

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,0 @@
-declare module 'json-parse-safe';

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,7 @@
         "@types/d3-scale": "4.0.8",
         "@types/jest": "29.5.12",
         "@types/jest-axe": "3.5.9",
+        "@types/json-parse-safe": "2.0.3",
         "@types/lodash": "4.14.202",
         "@types/numeral": "2.0.5",
         "@types/pluralize": "0.0.33",
@@ -9874,6 +9875,12 @@
         "@types/tough-cookie": "*",
         "parse5": "^7.0.0"
       }
+    },
+    "node_modules/@types/json-parse-safe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/json-parse-safe/-/json-parse-safe-2.0.3.tgz",
+      "integrity": "sha512-lVLo1xBRy1ZZtyZC4ekRxMLi6yhq19zreodli9RieXRjG2HjKez0759hze1wQqNGVFKgl3viHpUeMJBheMj8OA==",
+      "dev": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@types/d3-scale": "4.0.8",
     "@types/jest": "29.5.12",
     "@types/jest-axe": "3.5.9",
+    "@types/json-parse-safe": "2.0.3",
     "@types/lodash": "4.14.202",
     "@types/numeral": "2.0.5",
     "@types/pluralize": "0.0.33",

--- a/src/components/AreaChart/index.stories.tsx
+++ b/src/components/AreaChart/index.stories.tsx
@@ -11,7 +11,6 @@ import { Typography } from '@mui/material';
 import { Meta, StoryObj } from '@storybook/react';
 
 import { Playground } from '~/helpers/playground';
-import { THEME_ENCOURA } from '~/styles';
 
 import {
   defaultData,
@@ -75,10 +74,7 @@ export const CustomColors: StoryObj<AreaChartProps> = {
   args: {
     areaKeys: ['A', 'B'],
     areaProps: { fillOpacity: 0.6 },
-    colors: [
-      THEME_ENCOURA.customColors.chart.secondary.first,
-      THEME_ENCOURA.customColors.chart.secondary.second,
-    ],
+    colors: ['#FF0000', '#00FF00'],
     data: largerDataset,
   },
 };

--- a/src/components/AreaChart/index.stories.tsx
+++ b/src/components/AreaChart/index.stories.tsx
@@ -75,10 +75,10 @@ export const CustomColors: StoryObj<AreaChartProps> = {
   args: {
     areaKeys: ['A', 'B'],
     areaProps: { fillOpacity: 0.6 },
-    colors: {
-      A: THEME_ENCOURA.customColors.chart.secondary.first,
-      B: THEME_ENCOURA.customColors.chart.secondary.second,
-    },
+    colors: [
+      THEME_ENCOURA.customColors.chart.secondary.first,
+      THEME_ENCOURA.customColors.chart.secondary.second,
+    ],
     data: largerDataset,
   },
 };
@@ -188,7 +188,7 @@ export const WithFixedHeightAndWidth: StoryObj<AreaChartProps> = {
 export const MoreRealisticExample: StoryObj<AreaChartProps> = {
   args: {
     areaKeys: ['A'],
-    colors: { A: '#225479' },
+    colors: ['#225479'],
     data: percentageData,
     xLabel: 'Percentage Graph',
     yAxisProps: { tickFormatter: v => `${v * 100}%` },

--- a/src/components/AreaChart/index.stories.tsx
+++ b/src/components/AreaChart/index.stories.tsx
@@ -16,8 +16,8 @@ import { THEME_ENCOURA } from '~/styles';
 import {
   defaultData,
   largerDataset,
-  percentageData,
   largerDatasetWith18Keys,
+  percentageData,
 } from './mocks';
 
 import { AreaChart, AreaChartProps } from '.';

--- a/src/components/AreaChart/index.stories.tsx
+++ b/src/components/AreaChart/index.stories.tsx
@@ -11,8 +11,14 @@ import { Typography } from '@mui/material';
 import { Meta, StoryObj } from '@storybook/react';
 
 import { Playground } from '~/helpers/playground';
+import { THEME_ENCOURA } from '~/styles';
 
-import { defaultData, largerDataset, percentageData } from './mocks';
+import {
+  defaultData,
+  largerDataset,
+  percentageData,
+  largerDatasetWith18Keys,
+} from './mocks';
 
 import { AreaChart, AreaChartProps } from '.';
 
@@ -53,7 +59,15 @@ export const WithMoreThanOneArea: StoryObj<AreaChartProps> = {
   args: {
     areaKeys: ['A', 'B'],
     areaProps: { fillOpacity: 0.6 },
-    data: largerDataset,
+    data: largerDatasetWith18Keys,
+  },
+};
+
+export const WithLargeDataSet: StoryObj<AreaChartProps> = {
+  args: {
+    areaKeys: ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L'],
+    areaProps: { fillOpacity: 0.6 },
+    data: largerDatasetWith18Keys,
   },
 };
 
@@ -61,7 +75,10 @@ export const CustomColors: StoryObj<AreaChartProps> = {
   args: {
     areaKeys: ['A', 'B'],
     areaProps: { fillOpacity: 0.6 },
-    colors: { A: 'red', B: 'pink' },
+    colors: {
+      A: THEME_ENCOURA.customColors.chart.secondary.first,
+      B: THEME_ENCOURA.customColors.chart.secondary.second,
+    },
     data: largerDataset,
   },
 };

--- a/src/components/AreaChart/index.tsx
+++ b/src/components/AreaChart/index.tsx
@@ -8,8 +8,8 @@
  */
 
 import { Grid } from '@mui/material';
+import { blue, green } from '@mui/material/colors';
 import { useTheme } from '@mui/material/styles';
-import clsx from 'clsx';
 import React from 'react';
 import {
   Area,
@@ -51,7 +51,6 @@ export interface AreaChartProps {
   areaProps?: Partial<AreaProps>;
   children?: React.ReactNode;
   colors?: AreaColorProps;
-  customizeFillColor?: (index: number, key: string) => string | undefined;
   data: AreaDataProps[];
   height?: number;
   legendProps?: LegendProps;
@@ -71,7 +70,6 @@ export interface AreaChartProps {
 export const AreaChart: React.FC<AreaChartProps> = ({
   children,
   colors,
-  customizeFillColor,
   areaProps,
   areaChartProps,
   responsiveContainerProps,
@@ -90,8 +88,18 @@ export const AreaChart: React.FC<AreaChartProps> = ({
   yLabelProps,
   yReferenceValue,
 }: AreaChartProps): React.ReactElement => {
-  const { customColors, palette, spacing, typography }: any = useTheme();
+  const { palette, spacing, typography }: any = useTheme();
 
+  // Supplies up to 18 default colors
+  const getDefaultChartColors = (index: number): string => {
+    const colorPalettes = [blue, green];
+    const paletteIndex = Math.floor(index / 9);
+    const colorIndex = (index % 9) * 100 + 100; // Color index will be between 100 - 900
+    const currentPalette = colorPalettes[paletteIndex % colorPalettes.length];
+    return (
+      currentPalette[colorIndex as keyof typeof blue] || palette.common.black
+    );
+  };
   return (
     <Grid container direction="column" item spacing={2} xs={12}>
       <ResponsiveContainer
@@ -173,33 +181,19 @@ export const AreaChart: React.FC<AreaChartProps> = ({
           {(yReferenceValue || yReferenceValue === 0) && (
             <ReferenceLine stroke={palette.grey[400]} y={yReferenceValue} />
           )}
-          {areaKeys.map((key, i) => (
-            <Area
-              dataKey={key}
-              fill={
-                customizeFillColor
-                  ? customizeFillColor(i, key)
-                  : clsx(
-                      i === 0 && customColors?.chart?.primary?.first,
-                      i === 1 && customColors?.chart?.primary?.second,
-                      i === 2 && customColors?.chart?.primary?.third,
-                      i === 3 && customColors?.chart?.primary?.fourth,
-                      i === 4 && customColors?.chart?.primary?.fifth,
-                      i === 5 && customColors?.chart?.primary?.sixth,
-                      i > 5 && palette.grey[700],
-                    )
-              }
-              fillOpacity={1}
-              key={`${key}-area`}
-              stroke="none"
-              style={
-                colors?.[key]
-                  ? { ...areaProps?.style, fill: colors[key] }
-                  : areaProps?.style
-              }
-              {...(areaProps as Omit<AreaProps, 'dataKey' | 'ref'>)}
-            />
-          ))}
+          {areaKeys.map((key, i) => {
+            return (
+              <Area
+                dataKey={key}
+                fill={colors?.[key] ? colors[key] : getDefaultChartColors(i)}
+                fillOpacity={1}
+                key={`${key}-area`}
+                stroke="none"
+                style={areaProps?.style || {}}
+                {...(areaProps as Omit<AreaProps, 'dataKey' | 'ref'>)}
+              />
+            );
+          })}
 
           {showLegend && (
             <Legend

--- a/src/components/AreaChart/index.tsx
+++ b/src/components/AreaChart/index.tsx
@@ -8,7 +8,6 @@
  */
 
 import { Grid } from '@mui/material';
-import { blue, green } from '@mui/material/colors';
 import { useTheme } from '@mui/material/styles';
 import React from 'react';
 import {
@@ -34,6 +33,8 @@ import {
   ValueType,
   NameType,
 } from 'recharts/types/component/DefaultTooltipContent';
+
+import DEFAULT_CHART_COLORS from '~/constants/DEFAULT_CHART_COLORS';
 
 export interface AreaDataProps {
   name?: string;
@@ -89,16 +90,6 @@ export const AreaChart: React.FC<AreaChartProps> = ({
 }: AreaChartProps): React.ReactElement => {
   const { palette, spacing, typography }: any = useTheme();
 
-  // Supplies up to 18 default colors
-  const getDefaultChartColors = (index: number): string => {
-    const colorPalettes = [blue, green];
-    const paletteIndex = Math.floor(index / 9);
-    const colorIndex = (index % 9) * 100 + 100; // Color index will be between 100 - 900
-    const currentPalette = colorPalettes[paletteIndex % colorPalettes.length];
-    return (
-      currentPalette[colorIndex as keyof typeof blue] || palette.common.black
-    );
-  };
   return (
     <Grid container direction="column" item spacing={2} xs={12}>
       <ResponsiveContainer
@@ -184,7 +175,7 @@ export const AreaChart: React.FC<AreaChartProps> = ({
             return (
               <Area
                 dataKey={key}
-                fill={colors?.[i] ? colors[i] : getDefaultChartColors(i)}
+                fill={colors?.[i] ? colors[i] : DEFAULT_CHART_COLORS[i]}
                 fillOpacity={1}
                 key={`${key}-area`}
                 stroke="none"

--- a/src/components/AreaChart/index.tsx
+++ b/src/components/AreaChart/index.tsx
@@ -44,12 +44,14 @@ export interface AreaColorProps {
   [key: string]: string;
 }
 
+// FIX ME: Figure out a better way to distinguish the colors prop from the
 export interface AreaChartProps {
   areaChartProps?: CategoricalChartProps;
   areaKeys: string[];
   areaProps?: Partial<AreaProps>;
   children?: React.ReactNode;
   colors?: AreaColorProps;
+  customizeFillColor?: (index: number, key: string) => string | undefined;
   data: AreaDataProps[];
   height?: number;
   legendProps?: LegendProps;
@@ -69,6 +71,7 @@ export interface AreaChartProps {
 export const AreaChart: React.FC<AreaChartProps> = ({
   children,
   colors,
+  customizeFillColor,
   areaProps,
   areaChartProps,
   responsiveContainerProps,
@@ -173,15 +176,19 @@ export const AreaChart: React.FC<AreaChartProps> = ({
           {areaKeys.map((key, i) => (
             <Area
               dataKey={key}
-              fill={clsx(
-                i === 0 && customColors?.chart?.primary?.first,
-                i === 1 && customColors?.chart?.primary?.second,
-                i === 2 && customColors?.chart?.primary?.third,
-                i === 3 && customColors?.chart?.primary?.fourth,
-                i === 4 && customColors?.chart?.primary?.fifth,
-                i === 5 && customColors?.chart?.primary?.sixth,
-                i > 5 && palette.grey[700],
-              )}
+              fill={
+                customizeFillColor
+                  ? customizeFillColor(i, key)
+                  : clsx(
+                      i === 0 && customColors?.chart?.primary?.first,
+                      i === 1 && customColors?.chart?.primary?.second,
+                      i === 2 && customColors?.chart?.primary?.third,
+                      i === 3 && customColors?.chart?.primary?.fourth,
+                      i === 4 && customColors?.chart?.primary?.fifth,
+                      i === 5 && customColors?.chart?.primary?.sixth,
+                      i > 5 && palette.grey[700],
+                    )
+              }
               fillOpacity={1}
               key={`${key}-area`}
               stroke="none"

--- a/src/components/AreaChart/index.tsx
+++ b/src/components/AreaChart/index.tsx
@@ -8,7 +8,7 @@
  */
 
 import { Grid } from '@mui/material';
-import { useTheme } from '@mui/material/styles';
+import { useTheme, useThemeProps } from '@mui/material/styles';
 import React from 'react';
 import {
   Area,
@@ -35,6 +35,7 @@ import {
 } from 'recharts/types/component/DefaultTooltipContent';
 
 import DEFAULT_CHART_COLORS from '~/constants/DEFAULT_CHART_COLORS';
+import DLS_COMPONENT_NAMES from '~/constants/DLS_COMPONENT_NAMES';
 
 export interface AreaDataProps {
   name?: string;
@@ -67,27 +68,31 @@ export interface AreaChartProps {
   yReferenceValue?: number;
 }
 
-export const AreaChart: React.FC<AreaChartProps> = ({
-  children,
-  colors,
-  areaProps,
-  areaChartProps,
-  responsiveContainerProps,
-  tooltipProps,
-  data,
-  height,
-  legendProps,
-  width,
-  showLegend = false,
-  areaKeys,
-  xAxisProps,
-  yAxisProps,
-  xLabel,
-  xLabelProps,
-  yLabel,
-  yLabelProps,
-  yReferenceValue,
-}: AreaChartProps): React.ReactElement => {
+export const AreaChart: React.FC<AreaChartProps> = (
+  inProps: AreaChartProps,
+): React.ReactElement<AreaChartProps> => {
+  const {
+    children,
+    colors = [],
+    areaProps,
+    areaChartProps,
+    responsiveContainerProps,
+    tooltipProps,
+    data,
+    height,
+    legendProps,
+    width,
+    showLegend = false,
+    areaKeys,
+    xAxisProps,
+    yAxisProps,
+    xLabel,
+    xLabelProps,
+    yLabel,
+    yLabelProps,
+    yReferenceValue,
+  } = useThemeProps({ name: DLS_COMPONENT_NAMES.AREA_CHART, props: inProps });
+
   const { palette, spacing, typography }: any = useTheme();
 
   return (
@@ -175,7 +180,7 @@ export const AreaChart: React.FC<AreaChartProps> = ({
             return (
               <Area
                 dataKey={key}
-                fill={colors?.[i] ? colors[i] : DEFAULT_CHART_COLORS[i]}
+                fill={colors[i] || DEFAULT_CHART_COLORS[i] || palette.grey[700]}
                 fillOpacity={1}
                 key={`${key}-area`}
                 stroke="none"

--- a/src/components/AreaChart/index.tsx
+++ b/src/components/AreaChart/index.tsx
@@ -44,13 +44,12 @@ export interface AreaColorProps {
   [key: string]: string;
 }
 
-// FIX ME: Figure out a better way to distinguish the colors prop from the
 export interface AreaChartProps {
   areaChartProps?: CategoricalChartProps;
   areaKeys: string[];
   areaProps?: Partial<AreaProps>;
   children?: React.ReactNode;
-  colors?: AreaColorProps;
+  colors?: string[];
   data: AreaDataProps[];
   height?: number;
   legendProps?: LegendProps;
@@ -185,7 +184,7 @@ export const AreaChart: React.FC<AreaChartProps> = ({
             return (
               <Area
                 dataKey={key}
-                fill={colors?.[key] ? colors[key] : getDefaultChartColors(i)}
+                fill={colors?.[i] ? colors[i] : getDefaultChartColors(i)}
                 fillOpacity={1}
                 key={`${key}-area`}
                 stroke="none"

--- a/src/components/AreaChart/mocks.tsx
+++ b/src/components/AreaChart/mocks.tsx
@@ -109,7 +109,8 @@ export const largerDataset = [
 export const largerDatasetWith18Keys: { [key: string]: number | string }[] =
   largerDataset.map(item => {
     const newItem: { [key: string]: number | string } = { name: item.name };
-    for (let i = 0; i < 18; i++) {
+    // eslint-disable-next-line no-loops/no-loops
+    for (let i = 0; i < 18; i += 1) {
       newItem[String.fromCharCode(65 + i)] = Math.floor(Math.random() * 100);
     }
     return newItem;

--- a/src/components/AreaChart/mocks.tsx
+++ b/src/components/AreaChart/mocks.tsx
@@ -105,3 +105,12 @@ export const largerDataset = [
     name: 'Day 6',
   },
 ];
+
+export const largerDatasetWith18Keys: { [key: string]: number | string }[] =
+  largerDataset.map(item => {
+    const newItem: { [key: string]: number | string } = { name: item.name };
+    for (let i = 0; i < 18; i++) {
+      newItem[String.fromCharCode(65 + i)] = Math.floor(Math.random() * 100);
+    }
+    return newItem;
+  });

--- a/src/components/SessionStorageKeySharer/index.stories.tsx
+++ b/src/components/SessionStorageKeySharer/index.stories.tsx
@@ -20,6 +20,7 @@ import {
 } from '@mui/material';
 import { Meta, StoryObj, StoryFn } from '@storybook/react';
 import JSONParseSafe from 'json-parse-safe';
+import { get } from 'lodash';
 import { useState, useEffect } from 'react';
 
 import { Playground } from '~/helpers/playground';
@@ -33,7 +34,7 @@ const Template: StoryFn<SessionStorageKeySharerProps> = ({
     sessionStorage.getItem(keyName) || '',
   );
 
-  const keyValue = JSONParseSafe(keyValueRaw).value || keyValueRaw;
+  const keyValue = get(JSONParseSafe(keyValueRaw), 'value') || keyValueRaw;
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const handleSetKeyValue = (kv: string): void => {

--- a/src/components/SessionStorageKeySharer/index.tsx
+++ b/src/components/SessionStorageKeySharer/index.tsx
@@ -8,6 +8,7 @@
  */
 
 import JSONParseSafe from 'json-parse-safe';
+import { get } from 'lodash';
 import { FC, useEffect } from 'react';
 
 import useLocalStorage from '~/hooks/useLocalStorage';
@@ -32,11 +33,13 @@ export const SessionStorageKeySharer: FC<SessionStorageKeySharerProps> = ({
   );
 
   const sessionStorageKeyValueParsed =
-    JSONParseSafe(sessionStorageKeyValue).value || sessionStorageKeyValue;
+    get(JSONParseSafe(sessionStorageKeyValue), 'value') ||
+    sessionStorageKeyValue;
   const localStorageKeyValueParsed =
-    JSONParseSafe(localStorageKeyValue).value || localStorageKeyValue;
+    get(JSONParseSafe(localStorageKeyValue), 'value') || localStorageKeyValue;
   const localStorageKeyRequestParsed =
-    JSONParseSafe(localStorageKeyRequest).value || localStorageKeyRequest;
+    get(JSONParseSafe(localStorageKeyRequest), 'value') ||
+    localStorageKeyRequest;
 
   // If we don't have the session key, request it from other tab(s) that
   // may have it in their Session Storage.

--- a/src/constants/DEFAULT_CHART_COLORS.ts
+++ b/src/constants/DEFAULT_CHART_COLORS.ts
@@ -9,16 +9,16 @@
 
 /* eslint-disable filenames/match-exported */
 
-import { blue, common, green } from '@mui/material/colors';
+import { blueGrey, common, grey } from '@mui/material/colors';
 import { range } from 'lodash';
 
 // An array of 18 hex color strings.
 export const DEFAULT_CHART_COLORS = range(18).map((i): string => {
-  const colorPalettes = [blue, green];
+  const colorPalettes = [blueGrey, grey];
   const paletteIndex = Math.floor(i / 9);
   const colorIndex = (i % 9) * 100 + 100; // Color index will be between 100 - 900
   const currentPalette = colorPalettes[paletteIndex % colorPalettes.length];
-  return currentPalette[colorIndex as keyof typeof blue] || common.black;
+  return currentPalette[colorIndex as keyof typeof blueGrey] || common.black;
 });
 
 export default DEFAULT_CHART_COLORS;

--- a/src/constants/DEFAULT_CHART_COLORS.ts
+++ b/src/constants/DEFAULT_CHART_COLORS.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) ACT, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @prettier
+ */
+
+/* eslint-disable filenames/match-exported */
+
+import { blue, common, green } from '@mui/material/colors';
+import { range } from 'lodash';
+
+// An array of 18 hex color strings.
+export const DEFAULT_CHART_COLORS = range(18).map((i): string => {
+  const colorPalettes = [blue, green];
+  const paletteIndex = Math.floor(i / 9);
+  const colorIndex = (i % 9) * 100 + 100; // Color index will be between 100 - 900
+  const currentPalette = colorPalettes[paletteIndex % colorPalettes.length];
+  return currentPalette[colorIndex as keyof typeof blue] || common.black;
+});
+
+export default DEFAULT_CHART_COLORS;

--- a/src/constants/DLS_COMPONENT_NAMES.ts
+++ b/src/constants/DLS_COMPONENT_NAMES.ts
@@ -7,8 +7,10 @@
  * @prettier
  */
 
-/* eslint-disable import/prefer-default-export */
+/* eslint-disable filenames/match-exported */
 
-export * from './DEFAULT_CHART_COLORS';
-export * from './DLS_COMPONENT_NAMES';
-export * from './SORT_DIRECTION_TYPES';
+export const DLS_COMPONENT_NAMES = {
+  AREA_CHART: 'DlsAreaChart',
+} as const;
+
+export default DLS_COMPONENT_NAMES;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -9,4 +9,5 @@
 
 /* eslint-disable import/prefer-default-export */
 
+export * from './DEFAULT_CHART_COLORS';
 export * from './SORT_DIRECTION_TYPES';

--- a/src/styles/themeEncoura/components.ts
+++ b/src/styles/themeEncoura/components.ts
@@ -16,6 +16,18 @@ import THEME_ENCOURA_CLASSIC from '~/styles/themeEncouraClassic';
 import COLORS from './colors';
 
 const COMPONENTS: Components = {
+  DlsAreaChart: {
+    defaultProps: {
+      colors: [
+        COLORS.CUSTOM.chart.primary.first,
+        COLORS.CUSTOM.chart.primary.second,
+        COLORS.CUSTOM.chart.primary.third,
+        COLORS.CUSTOM.chart.primary.fourth,
+        COLORS.CUSTOM.chart.primary.fifth,
+        COLORS.CUSTOM.chart.primary.sixth,
+      ],
+    },
+  },
   MuiAvatar: {
     styleOverrides: {
       root: {

--- a/src/types/components.d.ts
+++ b/src/types/components.d.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) ACT, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @prettier
+ */
+
+import {
+  ComponentsOverrides,
+  ComponentsVariants,
+  Theme as MuiTheme,
+} from '@mui/material/styles';
+
+import { AreaChartProps } from '~/components/AreaChart';
+import DLS_COMPONENT_NAMES from '~/constants/DLS_COMPONENT_NAMES';
+
+type Theme = Omit<MuiTheme, 'components'>;
+
+declare module '@mui/material/styles' {
+  interface ComponentNameToClassKey {}
+
+  interface ComponentsPropsList {
+    [DLS_COMPONENT_NAMES.AREA_CHART]: Partial<AreaChartProps>;
+  }
+
+  interface Components {
+    [DLS_COMPONENT_NAMES.AREA_CHART]?: {
+      defaultProps?: ComponentsPropsList[typeof DLS_COMPONENT_NAMES.AREA_CHART];
+      styleOverrides?: ComponentsOverrides<Theme>[typeof DLS_COMPONENT_NAMES.AREA_CHART];
+      variants?: ComponentsVariants[typeof DLS_COMPONENT_NAMES.AREA_CHART];
+    };
+  }
+}


### PR DESCRIPTION
Currently showing proof of concept for the AreaChart component. If my colleagues like this approach then I'll proceed with converting the other components to use similar functionality. 