### PR TITLE
feat: Improve the customizability (and default behavior) of chart components across themes

### DIFF
--- a/src/components/AreaChart/index.tsx
+++ b/src/components/AreaChart/index.tsx
@@ -146,11 +146,6 @@ export const AreaChart: React.FC<AreaChartProps> = (
           <YAxis
             axisLine={false}
             padding={{ bottom: 20, top: 20 }}
-            style={{
-              fill: palette.secondary.dark,
-              fontSize: typography.h4.fontSize,
-              fontWeight: Number(typography.fontWeightRegular),
-            }}
             tickCount={5}
             tickLine={false}
             type="number"

--- a/src/components/AreaChart/index.tsx
+++ b/src/components/AreaChart/index.tsx
@@ -120,10 +120,6 @@ export const AreaChart: React.FC<AreaChartProps> = (
             height={50}
             orientation="bottom"
             padding={{ left: 40, right: 30 }}
-            style={{
-              fill: palette.secondary.dark,
-              fontSize: typography.caption.fontSize,
-            }}
             tickLine={false}
             xAxisId={0}
             {...xAxisProps}

--- a/src/components/BarChart/CustomizedAxisTick/__snapshots__/index.test.tsx.snap
+++ b/src/components/BarChart/CustomizedAxisTick/__snapshots__/index.test.tsx.snap
@@ -10,13 +10,13 @@ exports[`CustomizedAxisTick ACT theme matches the snapshot 1`] = `
     width="80"
     y="157"
   >
-    <h3
+    <p
       aria-label="Latino/Hispanic/Chicano"
-      class="MuiTypography-root MuiTypography-h3 MuiTypography-noWrap css-950bch-MuiTypography-root"
+      class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap  css-1w517f4-MuiTypography-root-DlsBarChart-yAxisLabel"
       data-mui-internal-clone-element="true"
     >
       Latino/Hispanic/Chicano
-    </h3>
+    </p>
   </foreignobject>
 </div>
 `;
@@ -31,13 +31,13 @@ exports[`CustomizedAxisTick ACT_ET theme matches the snapshot 1`] = `
     width="80"
     y="157"
   >
-    <h3
+    <p
       aria-label="Latino/Hispanic/Chicano"
-      class="MuiTypography-root MuiTypography-h3 MuiTypography-noWrap css-t015wh-MuiTypography-root"
+      class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap  css-rnmgd8-MuiTypography-root-DlsBarChart-yAxisLabel"
       data-mui-internal-clone-element="true"
     >
       Latino/Hispanic/Chicano
-    </h3>
+    </p>
   </foreignobject>
 </div>
 `;
@@ -52,13 +52,13 @@ exports[`CustomizedAxisTick ENCOURA theme matches the snapshot 1`] = `
     width="80"
     y="157"
   >
-    <h3
+    <p
       aria-label="Latino/Hispanic/Chicano"
-      class="MuiTypography-root MuiTypography-h3 MuiTypography-noWrap css-1n4e5ta-MuiTypography-root"
+      class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap  css-sh4ijp-MuiTypography-root-DlsBarChart-yAxisLabel"
       data-mui-internal-clone-element="true"
     >
       Latino/Hispanic/Chicano
-    </h3>
+    </p>
   </foreignobject>
 </div>
 `;
@@ -73,13 +73,13 @@ exports[`CustomizedAxisTick ENCOURA_CLASSIC theme matches the snapshot 1`] = `
     width="80"
     y="157"
   >
-    <h3
+    <p
       aria-label="Latino/Hispanic/Chicano"
-      class="MuiTypography-root MuiTypography-h3 MuiTypography-noWrap css-1n4e5ta-MuiTypography-root"
+      class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap  css-sh4ijp-MuiTypography-root-DlsBarChart-yAxisLabel"
       data-mui-internal-clone-element="true"
     >
       Latino/Hispanic/Chicano
-    </h3>
+    </p>
   </foreignobject>
 </div>
 `;
@@ -94,13 +94,13 @@ exports[`CustomizedAxisTick ENCOURAGE theme matches the snapshot 1`] = `
     width="80"
     y="157"
   >
-    <h3
+    <p
       aria-label="Latino/Hispanic/Chicano"
-      class="MuiTypography-root MuiTypography-h3 MuiTypography-noWrap css-zwskne-MuiTypography-root"
+      class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap  css-6r7ufn-MuiTypography-root-DlsBarChart-yAxisLabel"
       data-mui-internal-clone-element="true"
     >
       Latino/Hispanic/Chicano
-    </h3>
+    </p>
   </foreignobject>
 </div>
 `;

--- a/src/components/BarChart/CustomizedAxisTick/index.tsx
+++ b/src/components/BarChart/CustomizedAxisTick/index.tsx
@@ -75,6 +75,7 @@ CustomizedAxisTick.defaultProps = {
   payload: undefined,
   textWidth: undefined,
   variant: undefined,
+  yAxisLabelTypographyProps: undefined,
 };
 
 export default CustomizedAxisTick;

--- a/src/components/BarChart/CustomizedAxisTick/index.tsx
+++ b/src/components/BarChart/CustomizedAxisTick/index.tsx
@@ -9,7 +9,7 @@
 
 /* eslint-disable security/detect-non-literal-regexp */
 
-import { Typography, TypographyProps, Tooltip } from '@mui/material';
+import { TypographyProps, Tooltip } from '@mui/material';
 import React from 'react';
 import { XAxisProps } from 'recharts';
 

--- a/src/components/BarChart/CustomizedAxisTick/index.tsx
+++ b/src/components/BarChart/CustomizedAxisTick/index.tsx
@@ -9,11 +9,13 @@
 
 /* eslint-disable security/detect-non-literal-regexp */
 
-import { Typography, Tooltip } from '@mui/material';
+import { Typography, TypographyProps, Tooltip } from '@mui/material';
 import React from 'react';
 import { XAxisProps } from 'recharts';
 
 import { VariantType } from '~/types';
+
+import { StyledTypography } from './styles';
 
 interface PayloadProps {
   value: string;
@@ -24,6 +26,7 @@ export type CustomizedAxisTickProps = XAxisProps & {
   payload?: PayloadProps;
   textWidth?: number;
   variant?: VariantType;
+  yAxisLabelTypographyProps?: TypographyProps;
 };
 
 export const CustomizedAxisTick: React.FC<CustomizedAxisTickProps> = ({
@@ -36,13 +39,13 @@ export const CustomizedAxisTick: React.FC<CustomizedAxisTickProps> = ({
   type,
   style,
   variant,
+  yAxisLabelTypographyProps,
 }): React.ReactElement<CustomizedAxisTickProps> => {
   const onClickHandler = (): void => {
     if (onClick && payload) {
       onClick(payload);
     }
   };
-
   return (
     <foreignObject
       height={height}
@@ -55,14 +58,13 @@ export const CustomizedAxisTick: React.FC<CustomizedAxisTickProps> = ({
       y={(y as number) - 20}
     >
       <Tooltip title={payload?.value || ''}>
-        <Typography
+        <StyledTypography
           noWrap
           onClick={onClickHandler}
-          sx={{ color: 'secondary.dark' }}
-          variant="h3"
+          {...yAxisLabelTypographyProps}
         >
           {payload?.value}
-        </Typography>
+        </StyledTypography>
       </Tooltip>
     </foreignObject>
   );

--- a/src/components/BarChart/CustomizedAxisTick/styles.ts
+++ b/src/components/BarChart/CustomizedAxisTick/styles.ts
@@ -7,6 +7,8 @@
  * @prettier
  */
 
+/* eslint-disable import/prefer-default-export */
+
 import { styled } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
 

--- a/src/components/BarChart/CustomizedAxisTick/styles.ts
+++ b/src/components/BarChart/CustomizedAxisTick/styles.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) ACT, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @prettier
+ */
+
+import { styled } from '@mui/material/styles';
+import Typography from '@mui/material/Typography';
+
+import DLS_COMPONENT_NAMES from '~/constants/DLS_COMPONENT_NAMES';
+import DLS_COMPONENT_SLOT_NAMES from '~/constants/DLS_COMPONENT_SLOT_NAMES';
+
+export const StyledTypography = styled(Typography, {
+  name: DLS_COMPONENT_NAMES.BAR_CHART,
+  slot: DLS_COMPONENT_SLOT_NAMES[DLS_COMPONENT_NAMES.BAR_CHART].Y_AXIS_LABEL,
+})(({ theme }) => ({
+  color: theme.palette.secondary.dark,
+  fontSize: theme.typography.caption.fontSize,
+  fontWeight: theme.typography.fontWeightBold,
+}));

--- a/src/components/BarChart/index.stories.tsx
+++ b/src/components/BarChart/index.stories.tsx
@@ -354,6 +354,18 @@ export const WithYAxisProps: StoryObj<BarChartProps> = {
   },
 };
 
+export const WithyAxisLabelTypographyProps: StoryObj<BarChartProps> = {
+  args: {
+    barKeys: defaultBarKeys,
+    data: defaultData,
+    yAxisLabelTypographyProps: {
+      sx: {
+        color: 'error.main',
+      },
+    },
+  },
+};
+
 export const WithCustomLabel: StoryObj<BarChartProps> = {
   args: {
     barKeys: defaultBarKeys,

--- a/src/components/BarChart/index.tsx
+++ b/src/components/BarChart/index.tsx
@@ -8,6 +8,7 @@
  */
 
 import { useTheme, useThemeProps } from '@mui/material/styles';
+import { TypographyProps } from '@mui/material/Typography';
 import { isFunction } from 'lodash';
 import numeral from 'numeral';
 import React, { useMemo } from 'react';
@@ -77,6 +78,7 @@ export interface BarChartProps {
   variant?: VariantType;
   width?: number | string;
   xAxisProps?: XAxisProps;
+  yAxisLabelTypographyProps?: TypographyProps;
   yAxisProps?: YAxisProps;
 }
 
@@ -124,6 +126,7 @@ export const BarChart: React.FC<BarChartProps> = (
     variant,
     width,
     xAxisProps,
+    yAxisLabelTypographyProps,
     yAxisProps,
   } = useThemeProps({ name: DLS_COMPONENT_NAMES.BAR_CHART, props: inProps });
 
@@ -262,14 +265,15 @@ export const BarChart: React.FC<BarChartProps> = (
           <YAxis
             dataKey="name"
             padding={{ bottom: 10, top: 10 }}
-            style={{
-              fill: palette.secondary.dark,
-              fontSize: typography.h4.fontSize,
-              fontWeight: Number(typography.fontWeightRegular),
-            }}
+            // style={{
+            //   fill: palette.secondary.dark,
+            //   fontSize: typography.h4.fontSize,
+            //   fontWeight: Number(typography.fontWeightRegular),
+            // }}
             tick={
               <CustomizedAxisTick
                 variant={variant}
+                yAxisLabelTypographyProps={yAxisLabelTypographyProps}
                 {...customizedAxisTickProps}
               />
             }

--- a/src/components/BarChart/index.tsx
+++ b/src/components/BarChart/index.tsx
@@ -384,6 +384,7 @@ BarChart.defaultProps = {
   variant: undefined,
   width: undefined,
   xAxisProps: undefined,
+  yAxisLabelTypographyProps: undefined,
   yAxisProps: undefined,
 };
 

--- a/src/components/BarChart/index.tsx
+++ b/src/components/BarChart/index.tsx
@@ -253,10 +253,6 @@ export const BarChart: React.FC<BarChartProps> = (
           <XAxis
             axisLine={false}
             orientation="top"
-            style={{
-              fill: palette.grey[700],
-              fontSize: typography.caption.fontSize,
-            }}
             tickFormatter={(v: number): string => numeral(v).format('0,0')}
             type="number"
             xAxisId={0}

--- a/src/components/BarChart/index.tsx
+++ b/src/components/BarChart/index.tsx
@@ -265,11 +265,6 @@ export const BarChart: React.FC<BarChartProps> = (
           <YAxis
             dataKey="name"
             padding={{ bottom: 10, top: 10 }}
-            // style={{
-            //   fill: palette.secondary.dark,
-            //   fontSize: typography.h4.fontSize,
-            //   fontWeight: Number(typography.fontWeightRegular),
-            // }}
             tick={
               <CustomizedAxisTick
                 variant={variant}

--- a/src/components/LineChart/index.stories.tsx
+++ b/src/components/LineChart/index.stories.tsx
@@ -8,6 +8,7 @@
  */
 
 import { Meta, StoryContext } from '@storybook/react';
+import { YAxisProps } from 'recharts';
 
 import DLS_COMPONENT_NAMES from '~/constants/DLS_COMPONENT_NAMES';
 import { Playground } from '~/helpers/playground';
@@ -58,8 +59,8 @@ export default {
 const getMergedYAxisProps = (
   args: LineChartProps,
   globals: StoryContext['globals'],
-) => {
-  const theme = globals.theme;
+): YAxisProps => {
+  const { theme } = globals;
   let yAxisStyle;
 
   switch (theme) {
@@ -91,16 +92,21 @@ const getMergedYAxisProps = (
   return { ...args.yAxisProps, ...yAxisStyle };
 };
 
-export const Default = (args: LineChartProps, context: StoryContext) => {
-  const mergedYAxisProps = getMergedYAxisProps(args, context.globals);
+export const Default = (
+  args: LineChartProps,
+  context: StoryContext,
+): JSX.Element => {
+  const { globals } = context;
+  const mergedYAxisProps = getMergedYAxisProps(args, globals);
   return <LineChart {...args} yAxisProps={mergedYAxisProps} />;
 };
 
 export const WithCustomLineColors = (
   args: LineChartProps,
   context: StoryContext,
-) => {
-  const mergedYAxisProps = getMergedYAxisProps(args, context.globals);
+): JSX.Element => {
+  const { globals } = context;
+  const mergedYAxisProps = getMergedYAxisProps(args, globals);
   return (
     <LineChart
       {...args}

--- a/src/components/LineChart/index.stories.tsx
+++ b/src/components/LineChart/index.stories.tsx
@@ -7,9 +7,14 @@
  * @prettier
  */
 
-import { Meta, StoryObj } from '@storybook/react';
+import { Meta, StoryContext } from '@storybook/react';
 
+import DLS_COMPONENT_NAMES from '~/constants/DLS_COMPONENT_NAMES';
 import { Playground } from '~/helpers/playground';
+import THEME_ACT from '~/styles/themeAct';
+import THEME_ACT_ET from '~/styles/themeActEt';
+import THEME_ENCOURA_CLASSIC from '~/styles/themeEncouraClassic';
+import THEME_ENCOURAGE_V2 from '~/styles/themeEncourage';
 
 import { DATA, defaultLineKeys, processDataFn, yAxisDataKey } from './mocks';
 
@@ -50,10 +55,57 @@ export default {
   title: 'Molecules / Charts / LineChart',
 } as Meta<LineChartProps>;
 
-export const Default: StoryObj<LineChartProps> = {};
+const getMergedYAxisProps = (
+  args: LineChartProps,
+  globals: StoryContext['globals'],
+) => {
+  const theme = globals.theme;
+  let yAxisStyle;
 
-export const WithCustomLineColors: StoryObj<LineChartProps> = {
-  args: {
-    colors: ['#FF0000', '#00FF00', '#0000FF'],
-  },
+  switch (theme) {
+    case 'ACT': {
+      yAxisStyle =
+        THEME_ACT?.components?.[DLS_COMPONENT_NAMES.LINE_CHART]?.defaultProps
+          ?.yAxisProps;
+      break;
+    }
+    case 'ACT_ET': {
+      yAxisStyle =
+        THEME_ACT_ET?.components?.[DLS_COMPONENT_NAMES.LINE_CHART]?.defaultProps
+          ?.yAxisProps;
+      break;
+    }
+    case 'ENCOURAGE': {
+      yAxisStyle =
+        THEME_ENCOURAGE_V2?.components?.[DLS_COMPONENT_NAMES.LINE_CHART]
+          ?.defaultProps?.yAxisProps;
+      break;
+    }
+    default: {
+      yAxisStyle =
+        THEME_ENCOURA_CLASSIC?.components?.[DLS_COMPONENT_NAMES.LINE_CHART]
+          ?.defaultProps?.yAxisProps;
+    }
+  }
+
+  return { ...args.yAxisProps, ...yAxisStyle };
+};
+
+export const Default = (args: LineChartProps, context: StoryContext) => {
+  const mergedYAxisProps = getMergedYAxisProps(args, context.globals);
+  return <LineChart {...args} yAxisProps={mergedYAxisProps} />;
+};
+
+export const WithCustomLineColors = (
+  args: LineChartProps,
+  context: StoryContext,
+) => {
+  const mergedYAxisProps = getMergedYAxisProps(args, context.globals);
+  return (
+    <LineChart
+      {...args}
+      colors={['#FF0000', '#00FF00', '#0000FF']}
+      yAxisProps={mergedYAxisProps}
+    />
+  );
 };

--- a/src/components/LineChart/index.tsx
+++ b/src/components/LineChart/index.tsx
@@ -80,7 +80,6 @@ export const LineChart: React.FC<LineChartProps> = (
   } = useThemeProps({ name: DLS_COMPONENT_NAMES.LINE_CHART, props: inProps });
 
   const { palette, spacing, typography } = useTheme();
-
   return (
     <StyledContainer
       height={height}
@@ -108,10 +107,6 @@ export const LineChart: React.FC<LineChartProps> = (
           <XAxis
             dataKey="label"
             orientation="bottom"
-            style={{
-              fill: palette.grey[700],
-              fontSize: typography.caption.fontSize,
-            }}
             tickCount={data.length}
             xAxisId={0}
             {...xAxisProps}
@@ -119,11 +114,6 @@ export const LineChart: React.FC<LineChartProps> = (
           <YAxis
             orientation="left"
             padding={{ bottom: 10, top: 10 }}
-            style={{
-              fill: palette.grey[700],
-              fontSize: typography.caption.fontSize,
-              fontWeight: Number(typography.fontWeightRegular),
-            }}
             tickFormatter={(v: number): string => numeral(v).format('0,0')}
             tickLine={false}
             yAxisId={0}

--- a/src/components/OverlappedBarChart/OverlappedLabel/index.tsx
+++ b/src/components/OverlappedBarChart/OverlappedLabel/index.tsx
@@ -15,26 +15,28 @@ import { LabelProps } from 'recharts';
 import { StyledText } from './styles';
 
 export type OverlappedLabelProps = LabelProps & {
+  barTextColors?: string[];
   data: Record<string, number | string>[];
   index: number;
+  innerBarTextColor?: string;
   isOutsideBar?: boolean;
   label: string;
-  labelColor?: string;
+  textColor?: string;
   outsideBarDataKey: string;
-  valueColor?: string;
 };
 
 export const OverlappedLabel: React.FC<OverlappedLabelProps> = ({
+  barTextColors,
   color,
   data,
   height,
   index,
+  innerBarTextColor,
   isOutsideBar,
   label,
-  labelColor,
   outsideBarDataKey,
+  textColor,
   value,
-  valueColor,
   width,
   x,
   y,
@@ -82,15 +84,14 @@ export const OverlappedLabel: React.FC<OverlappedLabelProps> = ({
     baselineY = Number(y) + parseInt(spacing(6), 10);
   }
 
+  const textFill = isInsideInnerBar
+    ? innerBarTextColor || barTextColors?.[0] || palette.text.primary
+    : textColor || color || palette.text.primary;
   return (
     <g>
       <StyledText
         dominantBaseline="middle"
-        fill={
-          isOutsideBar || isInsideInnerBar
-            ? palette.text.primary
-            : labelColor || color
-        }
+        fill={textFill}
         textAnchor="middle"
         x={(x as number) + (width as number) / 2}
         y={baselineY - parseInt(spacing(2), 10)}
@@ -99,11 +100,7 @@ export const OverlappedLabel: React.FC<OverlappedLabelProps> = ({
       </StyledText>
       <StyledText
         dominantBaseline="middle"
-        fill={
-          isOutsideBar || isInsideInnerBar
-            ? palette.text.primary
-            : valueColor || color
-        }
+        fill={textFill}
         textAnchor="middle"
         x={(x as number) + (width as number) / 2}
         y={baselineY}
@@ -115,9 +112,10 @@ export const OverlappedLabel: React.FC<OverlappedLabelProps> = ({
 };
 
 OverlappedLabel.defaultProps = {
+  barTextColors: undefined,
+  innerBarTextColor: undefined,
   isOutsideBar: undefined,
-  labelColor: undefined,
-  valueColor: undefined,
+  textColor: undefined,
 };
 
 export default OverlappedLabel;

--- a/src/components/OverlappedBarChart/OverlappedLabel/styles.ts
+++ b/src/components/OverlappedBarChart/OverlappedLabel/styles.ts
@@ -11,7 +11,14 @@
 
 import { styled } from '@mui/material/styles';
 
-export const StyledText = styled('text')(({ theme }) => ({
-  fontSize: theme.typography.h3.fontSize,
+import DLS_COMPONENT_NAMES from '~/constants/DLS_COMPONENT_NAMES';
+import DLS_COMPONENT_SLOT_NAMES from '~/constants/DLS_COMPONENT_SLOT_NAMES';
+
+export const StyledText = styled('text', {
+  name: DLS_COMPONENT_NAMES.OVERLAPPED_BAR_CHART,
+  slot: DLS_COMPONENT_SLOT_NAMES[DLS_COMPONENT_NAMES.OVERLAPPED_BAR_CHART]
+    .BAR_LABELS,
+})(({ theme }) => ({
+  fontSize: theme.typography.caption.fontSize,
   fontWeight: Number(theme.typography.fontWeightBold),
 }));

--- a/src/components/OverlappedBarChart/index.stories.tsx
+++ b/src/components/OverlappedBarChart/index.stories.tsx
@@ -54,6 +54,15 @@ export const CloseData: StoryObj<OverlappedBarChartProps> = {
   },
 };
 
+export const WithCustomizableInnerBarTextColor: StoryObj<OverlappedBarChartProps> =
+  {
+    args: {
+      barKeys: ['inquiries', 'applicants'],
+      data: edgeCaseCloseData,
+      innerBarTextColor: 'red',
+    },
+  };
+
 export const LowData: StoryObj<OverlappedBarChartProps> = {
   args: {
     barKeys: ['inquiries', 'applicants'],

--- a/src/components/OverlappedBarChart/index.tsx
+++ b/src/components/OverlappedBarChart/index.tsx
@@ -77,7 +77,14 @@ export const OverlappedBarChart: React.FC<OverlappedBarChartProps> = (
         margin: { top: parseInt(String(spacing(5)), 10) },
       }}
       data={data}
-      tooltipProps={{ contentStyle: { backgroundColor: palette.common.white } }}
+      tooltipProps={{
+        contentStyle: {
+          backgroundColor: palette.common.white,
+        },
+        wrapperStyle: {
+          textTransform: 'capitalize',
+        },
+      }}
       xAxisProps={{
         dataKey: 'name',
         hide: true,

--- a/src/components/OverlappedBarChart/index.tsx
+++ b/src/components/OverlappedBarChart/index.tsx
@@ -38,10 +38,12 @@ export interface OverlappedBarChartProps {
   barChartProps?: Omit<BarChartProps, 'data'>;
   barKeys: string[];
   barProps?: Omit<BarProps, 'dataKey' | 'ref'>;
+  barTextColors?: string[]; // From the most outter bar to the most inner bar
   children?: React.ReactElement<unknown>;
   colors?: string[];
   data: Array<OverlappedBarDataProps>;
   initialBarSize?: number;
+  innerBarTextColor?: string;
   labelProps?: LabelListProps<ILabelListData>;
   xAxisProps?: XAxisProps;
 }
@@ -53,10 +55,12 @@ export const OverlappedBarChart: React.FC<OverlappedBarChartProps> = (
     barChartProps,
     barKeys,
     barProps,
+    barTextColors,
     children,
     colors = [],
     data,
     initialBarSize = 320,
+    innerBarTextColor,
     labelProps,
     xAxisProps,
   } = useThemeProps({
@@ -65,7 +69,6 @@ export const OverlappedBarChart: React.FC<OverlappedBarChartProps> = (
   });
 
   const { palette, spacing } = useTheme();
-
   return (
     <BarChart
       cartesianGridProps={{ stroke: palette.common.white }}
@@ -116,8 +119,7 @@ export const OverlappedBarChart: React.FC<OverlappedBarChartProps> = (
                   content={
                     <OverlappedLabel
                       isOutsideBar
-                      labelColor={palette.text.primary}
-                      valueColor={palette.secondary.dark}
+                      textColor={barTextColors?.[index]}
                       {...commonLabelProps}
                     />
                   }
@@ -142,8 +144,9 @@ export const OverlappedBarChart: React.FC<OverlappedBarChartProps> = (
                 <LabelList
                   content={
                     <OverlappedLabel
-                      labelColor={palette.common.white}
-                      valueColor={palette.common.white}
+                      barTextColors={barTextColors}
+                      innerBarTextColor={innerBarTextColor}
+                      textColor={barTextColors?.[index]}
                       {...commonLabelProps}
                     />
                   }
@@ -164,9 +167,11 @@ export const OverlappedBarChart: React.FC<OverlappedBarChartProps> = (
 OverlappedBarChart.defaultProps = {
   barChartProps: undefined,
   barProps: undefined,
+  barTextColors: undefined,
   children: undefined,
   colors: undefined,
   initialBarSize: undefined,
+  innerBarTextColor: undefined,
   labelProps: undefined,
   xAxisProps: undefined,
 };

--- a/src/components/PieChart/PieLegend/__snapshots__/index.test.tsx.snap
+++ b/src/components/PieChart/PieLegend/__snapshots__/index.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`PieLegend ACT theme matches the snapshot 1`] = `
         />
       </div>
       <div
-        class="MuiListItemText-root MuiListItemText-multiline css-afp7q8-MuiListItemText-root"
+        class="MuiListItemText-root MuiListItemText-multiline css-1unzhjx-MuiListItemText-root-DlsPieChart-pieLegendLabel"
       >
         <span
           class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-1n3v36-MuiTypography-root"
@@ -56,7 +56,7 @@ exports[`PieLegend ACT_ET theme matches the snapshot 1`] = `
         />
       </div>
       <div
-        class="MuiListItemText-root MuiListItemText-multiline css-zzkbu5-MuiListItemText-root"
+        class="MuiListItemText-root MuiListItemText-multiline css-14l206w-MuiListItemText-root-DlsPieChart-pieLegendLabel"
       >
         <span
           class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-1huj8uh-MuiTypography-root"
@@ -93,7 +93,7 @@ exports[`PieLegend ENCOURA theme matches the snapshot 1`] = `
         />
       </div>
       <div
-        class="MuiListItemText-root MuiListItemText-multiline css-1hfit64-MuiListItemText-root"
+        class="MuiListItemText-root MuiListItemText-multiline css-1niii2h-MuiListItemText-root-DlsPieChart-pieLegendLabel"
       >
         <span
           class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-1m3mbie-MuiTypography-root"
@@ -130,7 +130,7 @@ exports[`PieLegend ENCOURA_CLASSIC theme matches the snapshot 1`] = `
         />
       </div>
       <div
-        class="MuiListItemText-root MuiListItemText-multiline css-18x9qc9-MuiListItemText-root"
+        class="MuiListItemText-root MuiListItemText-multiline css-vysnbr-MuiListItemText-root-DlsPieChart-pieLegendLabel"
       >
         <span
           class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-1m3mbie-MuiTypography-root"
@@ -167,7 +167,7 @@ exports[`PieLegend ENCOURAGE theme matches the snapshot 1`] = `
         />
       </div>
       <div
-        class="MuiListItemText-root MuiListItemText-multiline css-prukgh-MuiListItemText-root"
+        class="MuiListItemText-root MuiListItemText-multiline css-i17rnf-MuiListItemText-root-DlsPieChart-pieLegendLabel"
       >
         <span
           class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-1sjf7d0-MuiTypography-root"

--- a/src/components/PieChart/PieLegend/index.tsx
+++ b/src/components/PieChart/PieLegend/index.tsx
@@ -34,6 +34,8 @@ export interface PayloadProps {
 
 export interface PieLegendProps extends Partial<LegendProps> {
   chartHeight?: number;
+  chartLegendTextFontSize?: number | string;
+  chartLegendTextFontSizeSmall?: number | string; // Used when the chartWidth & chartHeight is less than 350 px
   chartWidth?: number;
   CustomLegendIcon?: CustomLegendComponentType;
   formatValue?: (
@@ -50,6 +52,8 @@ export const PieLegend: React.FC<PieLegendProps> = (
   const {
     CustomLegendIcon,
     chartHeight,
+    chartLegendTextFontSize,
+    chartLegendTextFontSizeSmall,
     chartWidth,
     formatValue,
     onMouseEnter,
@@ -66,7 +70,6 @@ export const PieLegend: React.FC<PieLegendProps> = (
   ): void => {
     onMouseEnter?.(element, index, e);
   };
-
   return (
     <StyledUl numberOfItems={payload?.length || 0}>
       {payload?.map((element, i) => {
@@ -110,6 +113,8 @@ export const PieLegend: React.FC<PieLegendProps> = (
             {entryPayload && (
               <StyledListItemText
                 chartHeight={chartHeight}
+                chartLegendTextFontSize={chartLegendTextFontSize}
+                chartLegendTextFontSizeSmall={chartLegendTextFontSizeSmall}
                 chartWidth={chartWidth}
                 primary={value}
                 secondary={
@@ -133,6 +138,8 @@ export const PieLegend: React.FC<PieLegendProps> = (
 
 PieLegend.defaultProps = {
   chartHeight: undefined,
+  chartLegendTextFontSize: undefined,
+  chartLegendTextFontSizeSmall: undefined,
   chartWidth: undefined,
   CustomLegendIcon: undefined,
   formatValue: undefined,

--- a/src/components/PieChart/PieLegend/styles.ts
+++ b/src/components/PieChart/PieLegend/styles.ts
@@ -19,13 +19,18 @@ import {
 import { listItemTextClasses } from '@mui/material/ListItemText';
 import { styled } from '@mui/material/styles';
 
+import DLS_COMPONENT_NAMES from '~/constants/DLS_COMPONENT_NAMES';
+import DLS_COMPONENT_SLOT_NAMES from '~/constants/DLS_COMPONENT_SLOT_NAMES';
+
 interface StyledListItemProps extends ListItemProps {
   chartWidth?: number | string;
 }
 
 interface StyledListItemTextProps extends ListItemTextProps {
-  chartWidth?: number | string;
   chartHeight?: number | string;
+  chartLegendTextFontSize?: number | string;
+  chartLegendTextFontSizeSmall?: number | string; // Used when the chartWidth & chartHeight is less than 350 px
+  chartWidth?: number | string;
 }
 
 interface StyledPaperProps extends PaperProps {
@@ -80,21 +85,28 @@ export const StyledPaper = styled(Paper)<StyledPaperProps>(
   }),
 );
 
-export const StyledListItemText = styled(ListItemText)<StyledListItemTextProps>(
-  ({ chartHeight, chartWidth, theme }) => ({
+export const StyledListItemText = styled(ListItemText, {
+  name: DLS_COMPONENT_NAMES.PIE_CHART,
+  slot: DLS_COMPONENT_SLOT_NAMES[DLS_COMPONENT_NAMES.PIE_CHART]
+    .PIE_LEGEND_LABEL,
+})<StyledListItemTextProps>(
+  ({
+    chartHeight,
+    chartLegendTextFontSize,
+    chartLegendTextFontSizeSmall,
+    chartWidth,
+    theme,
+  }) => ({
     [`& .${listItemTextClasses.primary}`]: {
-      color: theme.palette.secondary.dark,
       fontSize:
         chartWidth &&
         Number(chartWidth) > 350 &&
         chartHeight &&
         Number(chartHeight) >= 350
-          ? (theme.typography.h4.fontSize as number)
-          : (theme.typography.h5.fontSize as number),
-      fontWeight: theme.typography.fontWeightBold,
-    },
-    [`& .${listItemTextClasses.secondary}`]: {
-      color: theme.palette.grey[700],
+          ? Number(chartLegendTextFontSize) ||
+            (theme.typography.body1.fontSize as number)
+          : Number(chartLegendTextFontSizeSmall) ||
+            (theme.typography.body2.fontSize as number),
     },
   }),
 );

--- a/src/components/PieChart/__snapshots__/index.test.tsx.snap
+++ b/src/components/PieChart/__snapshots__/index.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`PieChart with title ACT theme matches the snapshot 1`] = `
       class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1cv6hlt-MuiGrid-root"
     >
       <p
-        class="MuiTypography-root MuiTypography-body2 MuiTypography-alignCenter  css-6zomj9-MuiTypography-root"
+        class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter  css-1oy616q-MuiTypography-root-DlsPieChart-titleText"
         title="Test Title"
       >
         Test Title
@@ -121,7 +121,7 @@ exports[`PieChart with title ACT_ET theme matches the snapshot 1`] = `
       class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1cv6hlt-MuiGrid-root"
     >
       <p
-        class="MuiTypography-root MuiTypography-body2 MuiTypography-alignCenter  css-wcma3b-MuiTypography-root"
+        class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter  css-1ktxr0x-MuiTypography-root-DlsPieChart-titleText"
         title="Test Title"
       >
         Test Title
@@ -148,7 +148,7 @@ exports[`PieChart with title ENCOURA theme matches the snapshot 1`] = `
       class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1cv6hlt-MuiGrid-root"
     >
       <p
-        class="MuiTypography-root MuiTypography-body2 MuiTypography-alignCenter  css-xitg2l-MuiTypography-root"
+        class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter  css-lnvz74-MuiTypography-root-DlsPieChart-titleText"
         title="Test Title"
       >
         Test Title
@@ -175,7 +175,7 @@ exports[`PieChart with title ENCOURA_CLASSIC theme matches the snapshot 1`] = `
       class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1cv6hlt-MuiGrid-root"
     >
       <p
-        class="MuiTypography-root MuiTypography-body2 MuiTypography-alignCenter  css-xitg2l-MuiTypography-root"
+        class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter  css-lnvz74-MuiTypography-root-DlsPieChart-titleText"
         title="Test Title"
       >
         Test Title
@@ -202,7 +202,7 @@ exports[`PieChart with title ENCOURAGE theme matches the snapshot 1`] = `
       class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-7w0t0-MuiGrid-root"
     >
       <p
-        class="MuiTypography-root MuiTypography-body2 MuiTypography-alignCenter  css-mej2r4-MuiTypography-root"
+        class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter  css-1d8wpyf-MuiTypography-root-DlsPieChart-titleText"
         title="Test Title"
       >
         Test Title

--- a/src/components/PieChart/index.tsx
+++ b/src/components/PieChart/index.tsx
@@ -52,6 +52,8 @@ type TitleProps = TypographyProps & {
 export type PieDataProps = TypesPieDataProps;
 
 export interface PieChartProps {
+  chartLegendTextFontSize?: number | string;
+  chartLegendTextFontSizeSmall?: number | string; // Used when the chartWidth & chartHeight is less than 350 px
   children?: React.ReactElement<unknown>;
   colors?: string[];
   CustomLegendIcon?: CustomLegendComponentType;
@@ -78,6 +80,8 @@ export const PieChart: React.FC<PieChartProps> = (
   inProps: PieChartProps,
 ): React.ReactElement<PieChartProps> => {
   const {
+    chartLegendTextFontSize,
+    chartLegendTextFontSizeSmall,
     children,
     colors = [],
     CustomLegendIcon,
@@ -189,6 +193,8 @@ export const PieChart: React.FC<PieChartProps> = (
               align={data.length > 4 || hasHighlight ? 'right' : 'center'}
               content={
                 <PieLegend
+                  chartLegendTextFontSize={chartLegendTextFontSize}
+                  chartLegendTextFontSizeSmall={chartLegendTextFontSizeSmall}
                   CustomLegendIcon={CustomLegendIcon}
                   pieTotalValue={pieTotalValue}
                   showAsSquare={
@@ -218,6 +224,8 @@ export const PieChart: React.FC<PieChartProps> = (
 };
 
 PieChart.defaultProps = {
+  chartLegendTextFontSize: undefined,
+  chartLegendTextFontSizeSmall: undefined,
   children: undefined,
   colors: undefined,
   CustomLegendIcon: undefined,

--- a/src/components/PieChart/index.tsx
+++ b/src/components/PieChart/index.tsx
@@ -120,7 +120,6 @@ export const PieChart: React.FC<PieChartProps> = (
           <StyledTypography
             align="center"
             hasHighlight={hasHighlight}
-            variant="body2"
             variantSize={variant}
             {...titleProps}
             className={clsx(titleProps.className && titleProps.className)}
@@ -206,8 +205,6 @@ export const PieChart: React.FC<PieChartProps> = (
 
             <Tooltip
               formatter={(v: ValueType): string => numeral(v).format('0,0')}
-              itemStyle={{ color: palette.secondary.dark }}
-              labelStyle={{ color: palette.secondary.dark }}
               wrapperStyle={{ outline: 'none' }}
               {...tooltipProps}
             />

--- a/src/components/PieChart/styles.ts
+++ b/src/components/PieChart/styles.ts
@@ -11,6 +11,8 @@ import { Typography, TypographyProps } from '@mui/material';
 import Grid, { gridClasses } from '@mui/material/Grid';
 import { styled } from '@mui/material/styles';
 
+import DLS_COMPONENT_NAMES from '~/constants/DLS_COMPONENT_NAMES';
+import DLS_COMPONENT_SLOT_NAMES from '~/constants/DLS_COMPONENT_SLOT_NAMES';
 import { VariantType } from '~/types';
 
 type StyledTypographyType = TypographyProps & {
@@ -18,15 +20,14 @@ type StyledTypographyType = TypographyProps & {
   variantSize?: VariantType;
 };
 
-export const StyledTypography = styled(Typography)<StyledTypographyType>(
-  ({ hasHighlight, theme, variantSize }) => ({
-    color: theme.palette.secondary.dark,
-    fontWeight: Number(theme.typography.fontWeightBold),
-    marginTop: variantSize ? theme.spacing(1.5) : 0,
-    paddingRight: hasHighlight ? theme.spacing(30) : 0,
-    paddingTop: hasHighlight ? theme.spacing(3) : 0,
-  }),
-);
+export const StyledTypography = styled(Typography, {
+  name: DLS_COMPONENT_NAMES.PIE_CHART,
+  slot: DLS_COMPONENT_SLOT_NAMES[DLS_COMPONENT_NAMES.PIE_CHART].TITLE_TEXT,
+})<StyledTypographyType>(({ hasHighlight, theme, variantSize }) => ({
+  marginTop: variantSize ? theme.spacing(1.5) : 0,
+  paddingRight: hasHighlight ? theme.spacing(30) : 0,
+  paddingTop: hasHighlight ? theme.spacing(3) : 0,
+}));
 
 export const StyledGridTitle = styled(Grid)(({ theme }) => ({
   [`&.${gridClasses.root}`]: {

--- a/src/components/ScatterPlot/CustomTooltip/index.tsx
+++ b/src/components/ScatterPlot/CustomTooltip/index.tsx
@@ -10,7 +10,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
 
-import { Typography } from '@mui/material';
 import Paper from '@mui/material/Paper';
 import { get } from 'lodash';
 import React from 'react';
@@ -19,6 +18,8 @@ import {
   ValueType,
   NameType,
 } from 'recharts/types/component/DefaultTooltipContent';
+
+import { StyledDataLabelTypography, StyledDataValueTypography } from './styles';
 
 import { IGroupDataPoint } from '../types';
 
@@ -46,21 +47,21 @@ export const CustomTooltip: React.FC<ICustomTooltipProps> = ({
     if (members?.length) {
       return members.map(el => (
         <>
-          <Typography sx={{ color: 'secondary.dark' }}>
+          <StyledDataLabelTypography>
             {el?.label || ''}
-          </Typography>
-          <Typography>x: {el.x}</Typography>
-          <Typography>y: {el.y}</Typography>
+          </StyledDataLabelTypography>
+          <StyledDataValueTypography>x: {el.x}</StyledDataValueTypography>
+          <StyledDataValueTypography>y: {el.y}</StyledDataValueTypography>
         </>
       ));
     }
     return (
       <>
-        <Typography sx={{ color: 'secondary.dark' }}>
+        <StyledDataLabelTypography>
           {data?.label || ''}
-        </Typography>
-        <Typography>x: {data?.x}</Typography>
-        <Typography>y: {data?.y}</Typography>
+        </StyledDataLabelTypography>
+        <StyledDataValueTypography>x: {data?.x}</StyledDataValueTypography>
+        <StyledDataValueTypography>y: {data?.y}</StyledDataValueTypography>
       </>
     );
   }

--- a/src/components/ScatterPlot/CustomTooltip/index.tsx
+++ b/src/components/ScatterPlot/CustomTooltip/index.tsx
@@ -19,9 +19,9 @@ import {
   NameType,
 } from 'recharts/types/component/DefaultTooltipContent';
 
-import { StyledDataLabelTypography, StyledDataValueTypography } from './styles';
-
 import { IGroupDataPoint } from '../types';
+
+import { StyledDataLabelTypography, StyledDataValueTypography } from './styles';
 
 type ICustomTooltipProps = {
   CustomTooltipContent?: React.ElementType;

--- a/src/components/ScatterPlot/CustomTooltip/styles.ts
+++ b/src/components/ScatterPlot/CustomTooltip/styles.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) ACT, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @prettier
+ */
+
+import { Typography, TypographyProps } from '@mui/material';
+import { common } from '@mui/material/colors';
+import { styled } from '@mui/material/styles';
+
+import DLS_COMPONENT_NAMES from '~/constants/DLS_COMPONENT_NAMES';
+import DLS_COMPONENT_SLOT_NAMES from '~/constants/DLS_COMPONENT_SLOT_NAMES';
+
+export const StyledDataLabelTypography = styled(Typography, {
+  name: DLS_COMPONENT_NAMES.SCATTER_PLOT,
+  slot: DLS_COMPONENT_SLOT_NAMES[DLS_COMPONENT_NAMES.SCATTER_PLOT]
+    .SCATTER_TOOLTIP_LABEL,
+})({
+  color: common.black,
+});
+
+export const StyledDataValueTypography = styled(Typography, {
+  name: DLS_COMPONENT_NAMES.SCATTER_PLOT,
+  slot: DLS_COMPONENT_SLOT_NAMES[DLS_COMPONENT_NAMES.SCATTER_PLOT]
+    .SCATTER_TOOLTIP_TEXT,
+})<TypographyProps>(({ theme }) => ({
+  color: theme.palette.text.primary,
+}));

--- a/src/components/ScatterPlot/CustomizedLabel/__snapshots__/index.test.tsx.snap
+++ b/src/components/ScatterPlot/CustomizedLabel/__snapshots__/index.test.tsx.snap
@@ -12,11 +12,10 @@ exports[`CustomizedLabel ACT theme matches the snapshot 1`] = `
   >
     <div
       aria-label="Test"
-      class=""
+      class=" css-1ulfqjm-DlsScatterPlot-scatterLabels"
       color="primary"
       data-mui-internal-clone-element="true"
-      style="opacity: 1; overflow: hidden; text-overflow: ellipsis; user-select: none; white-space: nowrap;"
-      sx="[object Object]"
+      opacity="1"
     >
       Test
     </div>
@@ -36,10 +35,9 @@ exports[`CustomizedLabel ACT_ET theme matches the snapshot 1`] = `
   >
     <div
       aria-label="Test"
-      class=""
+      class=" css-1ulfqjm-DlsScatterPlot-scatterLabels"
       data-mui-internal-clone-element="true"
-      style="opacity: 1; overflow: hidden; text-overflow: ellipsis; user-select: none; white-space: nowrap;"
-      sx="[object Object]"
+      opacity="1"
     >
       Test
     </div>
@@ -59,10 +57,9 @@ exports[`CustomizedLabel ENCOURA theme matches the snapshot 1`] = `
   >
     <div
       aria-label="Test"
-      class=""
+      class=" css-8j61u7-DlsScatterPlot-scatterLabels"
       data-mui-internal-clone-element="true"
-      style="opacity: 1; overflow: hidden; text-overflow: ellipsis; user-select: none; white-space: nowrap;"
-      sx="[object Object]"
+      opacity="1"
     >
       Test
     </div>
@@ -82,10 +79,9 @@ exports[`CustomizedLabel ENCOURA_CLASSIC theme matches the snapshot 1`] = `
   >
     <div
       aria-label="Test"
-      class=""
+      class=" css-8j61u7-DlsScatterPlot-scatterLabels"
       data-mui-internal-clone-element="true"
-      style="opacity: 1; overflow: hidden; text-overflow: ellipsis; user-select: none; white-space: nowrap;"
-      sx="[object Object]"
+      opacity="1"
     >
       Test
     </div>
@@ -105,10 +101,9 @@ exports[`CustomizedLabel ENCOURAGE theme matches the snapshot 1`] = `
   >
     <div
       aria-label="Test"
-      class=""
+      class=" css-1ulfqjm-DlsScatterPlot-scatterLabels"
       data-mui-internal-clone-element="true"
-      style="opacity: 1; overflow: hidden; text-overflow: ellipsis; user-select: none; white-space: nowrap;"
-      sx="[object Object]"
+      opacity="1"
     >
       Test
     </div>

--- a/src/components/ScatterPlot/CustomizedLabel/index.tsx
+++ b/src/components/ScatterPlot/CustomizedLabel/index.tsx
@@ -13,6 +13,8 @@ import { LabelProps } from 'recharts';
 
 import { ScatterPlotData } from '~/types';
 
+import { StyledLabel } from './styles';
+
 export type CustomizedLabelProps = LabelProps & {
   fontSize?: number;
   fontWeight?: number;
@@ -30,8 +32,6 @@ export const MIN_LABEL_WIDTH = 40;
 
 export const CustomizedLabel: React.FC<CustomizedLabelProps> = ({
   fill,
-  fontSize,
-  fontWeight,
   isBlockingOnHovers,
   selectedPoint,
   shouldHideLabel = {},
@@ -54,7 +54,6 @@ export const CustomizedLabel: React.FC<CustomizedLabelProps> = ({
   if (shouldHideLabel[value as string] && !isThisSelectedPoint) {
     return null;
   }
-
   return (
     <foreignObject
       height={30}
@@ -65,38 +64,14 @@ export const CustomizedLabel: React.FC<CustomizedLabelProps> = ({
       y={(y as number) - Y_LABEL_MARGIN}
     >
       {isBlockingOnHovers ? (
-        <div
-          style={{
-            color: fill,
-            fill,
-            fontSize,
-            fontWeight,
-            opacity,
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            userSelect: 'none',
-            whiteSpace: 'nowrap',
-          }}
-        >
+        <StyledLabel fill={fill} opacity={opacity}>
           {value}
-        </div>
+        </StyledLabel>
       ) : (
         <Tooltip sx={{ userSelect: 'none' }} title={value || ''}>
-          <div
-            style={{
-              color: fill,
-              fill,
-              fontSize,
-              fontWeight,
-              opacity,
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              userSelect: 'none',
-              whiteSpace: 'nowrap',
-            }}
-          >
+          <StyledLabel fill={fill} opacity={opacity}>
             {value}
-          </div>
+          </StyledLabel>
         </Tooltip>
       )}
     </foreignObject>

--- a/src/components/ScatterPlot/CustomizedLabel/index.tsx
+++ b/src/components/ScatterPlot/CustomizedLabel/index.tsx
@@ -16,8 +16,6 @@ import { ScatterPlotData } from '~/types';
 import { StyledLabel } from './styles';
 
 export type CustomizedLabelProps = LabelProps & {
-  fontSize?: number;
-  fontWeight?: number;
   isBlockingOnHovers?: boolean;
   selectedPoint?: ScatterPlotData;
   shouldHideLabel?: Record<string, boolean>;
@@ -79,8 +77,6 @@ export const CustomizedLabel: React.FC<CustomizedLabelProps> = ({
 };
 
 CustomizedLabel.defaultProps = {
-  fontSize: undefined,
-  fontWeight: undefined,
   isBlockingOnHovers: undefined,
   selectedPoint: undefined,
   shouldHideLabel: undefined,

--- a/src/components/ScatterPlot/CustomizedLabel/styles.ts
+++ b/src/components/ScatterPlot/CustomizedLabel/styles.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) ACT, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @prettier
+ */
+
+/* eslint-disable import/prefer-default-export */
+
+import { styled } from '@mui/material/styles';
+
+import DLS_COMPONENT_NAMES from '~/constants/DLS_COMPONENT_NAMES';
+import DLS_COMPONENT_SLOT_NAMES from '~/constants/DLS_COMPONENT_SLOT_NAMES';
+
+interface CustomizedLabelProps {
+  fill?: string;
+  opacity?: number;
+}
+
+export const StyledLabel = styled('div', {
+  name: DLS_COMPONENT_NAMES.SCATTER_PLOT,
+  slot: DLS_COMPONENT_SLOT_NAMES[DLS_COMPONENT_NAMES.SCATTER_PLOT]
+    .SCATTER_LABELS,
+})<CustomizedLabelProps>(({ fill, opacity }) => ({
+  color: fill,
+  fill: fill,
+  opacity: opacity,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  userSelect: 'none',
+  whiteSpace: 'nowrap',
+}));

--- a/src/components/ScatterPlot/CustomizedLabel/styles.ts
+++ b/src/components/ScatterPlot/CustomizedLabel/styles.ts
@@ -25,8 +25,8 @@ export const StyledLabel = styled('div', {
     .SCATTER_LABELS,
 })<CustomizedLabelProps>(({ fill, opacity }) => ({
   color: fill,
-  fill: fill,
-  opacity: opacity,
+  fill,
+  opacity,
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   userSelect: 'none',

--- a/src/components/ScatterPlot/index.stories.tsx
+++ b/src/components/ScatterPlot/index.stories.tsx
@@ -17,9 +17,9 @@ import THEME_ENCOURA_CLASSIC from '~/styles/themeEncouraClassic';
 import THEME_ENCOURAGE_V2 from '~/styles/themeEncourage';
 
 import { defaultData, LARGE_DATA } from './mocks';
+import { CustomYAxisProps } from './types';
 
 import { ScatterPlot, ScatterPlotProps } from '.';
-import { CustomYAxisProps } from './types';
 
 export default {
   args: {
@@ -61,8 +61,8 @@ export default {
 const getMergedYAxisProps = (
   args: ScatterPlotProps,
   globals: StoryContext['globals'],
-) => {
-  const theme = globals.theme;
+): CustomYAxisProps => {
+  const { theme } = globals;
   let yAxisStyle;
 
   switch (theme) {
@@ -94,26 +94,38 @@ const getMergedYAxisProps = (
   return { ...args.yAxisProps, ...yAxisStyle } as CustomYAxisProps;
 };
 
-export const Default = (args: ScatterPlotProps, context: StoryContext) => {
-  const mergedYAxisProps = getMergedYAxisProps(args, context.globals);
+export const Default = (
+  args: ScatterPlotProps,
+  context: StoryContext,
+): JSX.Element => {
+  const { globals } = context;
+  const mergedYAxisProps = getMergedYAxisProps(args, globals);
   return <ScatterPlot {...args} yAxisProps={mergedYAxisProps} />;
 };
 
-export const CustomColor = (args: ScatterPlotProps, context: StoryContext) => {
-  const mergedYAxisProps = getMergedYAxisProps(args, context.globals);
-  return <ScatterPlot {...args} color={'red'} yAxisProps={mergedYAxisProps} />;
+export const CustomColor = (
+  args: ScatterPlotProps,
+  context: StoryContext,
+): JSX.Element => {
+  const { globals } = context;
+  const mergedYAxisProps = getMergedYAxisProps(args, globals);
+  return <ScatterPlot {...args} color="red" yAxisProps={mergedYAxisProps} />;
 };
 
-export const LargeDataset = (args: ScatterPlotProps, context: StoryContext) => {
-  const mergedYAxisProps = getMergedYAxisProps(args, context.globals);
+export const LargeDataset = (
+  args: ScatterPlotProps,
+  context: StoryContext,
+): JSX.Element => {
+  const { globals } = context;
+  const mergedYAxisProps = getMergedYAxisProps(args, globals);
   return (
     <ScatterPlot
       {...args}
       data={LARGE_DATA}
       height={600}
       xLabelValue="X Value"
-      yLabelValue="Y Value"
       yAxisProps={mergedYAxisProps}
+      yLabelValue="Y Value"
     />
   );
 };
@@ -121,8 +133,9 @@ export const LargeDataset = (args: ScatterPlotProps, context: StoryContext) => {
 export const WithoutRankSummary = (
   args: ScatterPlotProps,
   context: StoryContext,
-) => {
-  const mergedYAxisProps = getMergedYAxisProps(args, context.globals);
+): JSX.Element => {
+  const { globals } = context;
+  const mergedYAxisProps = getMergedYAxisProps(args, globals);
   return (
     <ScatterPlot
       {...args}
@@ -130,8 +143,8 @@ export const WithoutRankSummary = (
       height={600}
       hideSummary
       xLabelValue="Inquiries to Applicants"
-      yLabelValue="Inquiries"
       yAxisProps={mergedYAxisProps}
+      yLabelValue="Inquiries"
     />
   );
 };

--- a/src/components/ScatterPlot/index.stories.tsx
+++ b/src/components/ScatterPlot/index.stories.tsx
@@ -7,13 +7,19 @@
  * @prettier
  */
 
-import { Meta, StoryObj } from '@storybook/react';
+import { Meta, StoryContext } from '@storybook/react';
 
+import DLS_COMPONENT_NAMES from '~/constants/DLS_COMPONENT_NAMES';
 import { Playground } from '~/helpers/playground';
+import THEME_ACT from '~/styles/themeAct';
+import THEME_ACT_ET from '~/styles/themeActEt';
+import THEME_ENCOURA_CLASSIC from '~/styles/themeEncouraClassic';
+import THEME_ENCOURAGE_V2 from '~/styles/themeEncourage';
 
 import { defaultData, LARGE_DATA } from './mocks';
 
 import { ScatterPlot, ScatterPlotProps } from '.';
+import { CustomYAxisProps } from './types';
 
 export default {
   args: {
@@ -52,29 +58,80 @@ export default {
   title: 'Molecules / Charts / ScatterPlot',
 } as Meta<ScatterPlotProps>;
 
-export const Default: StoryObj<ScatterPlotProps> = {};
+const getMergedYAxisProps = (
+  args: ScatterPlotProps,
+  globals: StoryContext['globals'],
+) => {
+  const theme = globals.theme;
+  let yAxisStyle;
 
-export const CustomColor: StoryObj<ScatterPlotProps> = {
-  args: {
-    color: 'red',
-  },
+  switch (theme) {
+    case 'ACT': {
+      yAxisStyle =
+        THEME_ACT?.components?.[DLS_COMPONENT_NAMES.SCATTER_PLOT]?.defaultProps
+          ?.yAxisProps;
+      break;
+    }
+    case 'ACT_ET': {
+      yAxisStyle =
+        THEME_ACT_ET?.components?.[DLS_COMPONENT_NAMES.SCATTER_PLOT]
+          ?.defaultProps?.yAxisProps;
+      break;
+    }
+    case 'ENCOURAGE': {
+      yAxisStyle =
+        THEME_ENCOURAGE_V2?.components?.[DLS_COMPONENT_NAMES.SCATTER_PLOT]
+          ?.defaultProps?.yAxisProps;
+      break;
+    }
+    default: {
+      yAxisStyle =
+        THEME_ENCOURA_CLASSIC?.components?.[DLS_COMPONENT_NAMES.SCATTER_PLOT]
+          ?.defaultProps?.yAxisProps;
+    }
+  }
+
+  return { ...args.yAxisProps, ...yAxisStyle } as CustomYAxisProps;
 };
 
-export const LargeDataset: StoryObj<ScatterPlotProps> = {
-  args: {
-    data: LARGE_DATA,
-    height: 600,
-    xLabelValue: 'X Value',
-    yLabelValue: 'Y Value',
-  },
+export const Default = (args: ScatterPlotProps, context: StoryContext) => {
+  const mergedYAxisProps = getMergedYAxisProps(args, context.globals);
+  return <ScatterPlot {...args} yAxisProps={mergedYAxisProps} />;
 };
 
-export const WithoutRankSummary: StoryObj<ScatterPlotProps> = {
-  args: {
-    data: LARGE_DATA,
-    height: 600,
-    hideSummary: true,
-    xLabelValue: 'Inquiries to Applicants',
-    yLabelValue: 'Inquiries',
-  },
+export const CustomColor = (args: ScatterPlotProps, context: StoryContext) => {
+  const mergedYAxisProps = getMergedYAxisProps(args, context.globals);
+  return <ScatterPlot {...args} color={'red'} yAxisProps={mergedYAxisProps} />;
+};
+
+export const LargeDataset = (args: ScatterPlotProps, context: StoryContext) => {
+  const mergedYAxisProps = getMergedYAxisProps(args, context.globals);
+  return (
+    <ScatterPlot
+      {...args}
+      data={LARGE_DATA}
+      height={600}
+      xLabelValue="X Value"
+      yLabelValue="Y Value"
+      yAxisProps={mergedYAxisProps}
+    />
+  );
+};
+
+export const WithoutRankSummary = (
+  args: ScatterPlotProps,
+  context: StoryContext,
+) => {
+  const mergedYAxisProps = getMergedYAxisProps(args, context.globals);
+  return (
+    <ScatterPlot
+      {...args}
+      data={LARGE_DATA}
+      height={600}
+      hideSummary
+      xLabelValue="Inquiries to Applicants"
+      yLabelValue="Inquiries"
+      yAxisProps={mergedYAxisProps}
+    />
+  );
 };

--- a/src/components/ScatterPlot/index.tsx
+++ b/src/components/ScatterPlot/index.tsx
@@ -8,6 +8,7 @@
  */
 
 import { Button } from '@mui/material';
+import { common } from '@mui/material/colors';
 import { useTheme, useThemeProps } from '@mui/material/styles';
 import { debounce } from 'lodash';
 import numeral from 'numeral';
@@ -81,13 +82,16 @@ export interface ScatterPlotProps {
   hideSummary?: boolean;
   idSubstring?: string;
   responsiveContainerProps?: ResponsiveContainerProps;
+  scatterLabelColor?: string;
   scatterProps?: ScatterProps;
   showAverageLine?: boolean;
   tooltipProps?: TooltipProps<ValueType, NameType>;
+  xAverageLineLabelProps?: LabelProps;
   xAverageLineProps?: ReferenceLineProps;
   xAxisProps?: CustomXAxisProps;
   xLabelProps?: LabelProps;
   xLabelValue?: string;
+  yAverageLineLabelProps?: LabelProps;
   yAverageLineProps?: ReferenceLineProps;
   yAxisProps?: CustomYAxisProps;
   yLabelProps?: LabelProps;
@@ -114,13 +118,16 @@ export const ScatterPlot: React.FC<ScatterPlotProps> = (
     hideSummary,
     idSubstring,
     responsiveContainerProps,
+    scatterLabelColor,
     scatterProps,
     showAverageLine = true,
     tooltipProps,
+    xAverageLineLabelProps,
     xAverageLineProps,
     xAxisProps,
     xLabelProps,
     xLabelValue,
+    yAverageLineLabelProps,
     yAverageLineProps,
     yAxisProps,
     yLabelProps,
@@ -440,12 +447,6 @@ export const ScatterPlot: React.FC<ScatterPlotProps> = (
             allowDecimals={false}
             dataKey="x"
             interval={0}
-            style={{
-              fill: palette.common.black,
-              fontSize: typography.caption.fontSize,
-              fontWeight: Number(typography.fontWeightRegular),
-              userSelect: 'none',
-            }}
             tickLine={false}
             type="number"
             {...xAxisProps}
@@ -465,12 +466,6 @@ export const ScatterPlot: React.FC<ScatterPlotProps> = (
             axisLine={{ stroke: palette.grey[400] }}
             dataKey="y"
             interval={0}
-            style={{
-              fill: palette.common.black,
-              fontSize: typography.caption.fontSize,
-              fontWeight: Number(typography.fontWeightRegular),
-              userSelect: 'none',
-            }}
             tickLine={false}
             type="number"
             unit="%"
@@ -497,8 +492,6 @@ export const ScatterPlot: React.FC<ScatterPlotProps> = (
               />
             }
             cursor={{ strokeDasharray: '3 3' }}
-            itemStyle={{ color: palette.secondary.dark }}
-            labelStyle={{ color: palette.secondary.dark }}
             wrapperStyle={{ outline: 'none' }}
             {...tooltipProps}
           />
@@ -513,36 +506,26 @@ export const ScatterPlot: React.FC<ScatterPlotProps> = (
             <>
               <ReferenceLine
                 opacity={selectedPoint ? OPACITY_NOT_HIGHLIGHTED : 1}
-                stroke={palette.grey[800]}
                 strokeDasharray="3 3"
                 x={xLineCoordinates}
                 {...xAverageLineProps}
               >
                 <Label
                   position="insideBottom"
-                  style={{
-                    fontSize: typography.h5.fontSize,
-                    fontWeight: Number(typography.fontWeightRegular),
-                    userSelect: 'none',
-                  }}
                   value={`Top N Average: ${formatAverageLineLabel(Number(xLineCoordinates))}`}
+                  {...xAverageLineLabelProps}
                 />
               </ReferenceLine>
               <ReferenceLine
                 opacity={selectedPoint ? OPACITY_NOT_HIGHLIGHTED : 1}
-                stroke={palette.grey[800]}
                 strokeDasharray="3 3"
                 y={yLineCoordinates}
                 {...yAverageLineProps}
               >
                 <Label
                   position="insideTopLeft"
-                  style={{
-                    fontSize: typography.h5.fontSize,
-                    fontWeight: Number(typography.fontWeightRegular),
-                    userSelect: 'none',
-                  }}
                   value={`Top N Average: ${formatAverageLineLabel(Number(yLineCoordinates))}%`}
+                  {...yAverageLineLabelProps}
                 />
               </ReferenceLine>
             </>
@@ -563,15 +546,13 @@ export const ScatterPlot: React.FC<ScatterPlotProps> = (
             <LabelList
               content={
                 <CustomizedLabel
-                  fontSize={typography?.h3?.fontSize as number | undefined}
-                  fontWeight={typography.h3.fontWeight as number | undefined}
                   isBlockingOnHovers={isBlockingOnHovers}
                   selectedPoint={selectedPoint}
                   shouldHideLabel={shouldHideLabel}
                 />
               }
               dataKey="label"
-              fill={palette.secondary.dark}
+              fill={scatterLabelColor || common.black}
               position="top"
             />
           </Scatter>
@@ -603,13 +584,16 @@ ScatterPlot.defaultProps = {
   hideSummary: undefined,
   idSubstring: undefined,
   responsiveContainerProps: undefined,
+  scatterLabelColor: undefined,
   scatterProps: undefined,
   showAverageLine: undefined,
   tooltipProps: undefined,
+  xAverageLineLabelProps: undefined,
   xAverageLineProps: undefined,
   xAxisProps: undefined,
   xLabelProps: undefined,
   xLabelValue: undefined,
+  yAverageLineLabelProps: undefined,
   yAverageLineProps: undefined,
   yAxisProps: undefined,
   yLabelProps: undefined,

--- a/src/components/StackedBarChart/index.stories.tsx
+++ b/src/components/StackedBarChart/index.stories.tsx
@@ -7,9 +7,14 @@
  * @prettier
  */
 
-import { Meta, StoryObj } from '@storybook/react';
+import { Meta, StoryContext, StoryObj } from '@storybook/react';
 
+import DLS_COMPONENT_NAMES from '~/constants/DLS_COMPONENT_NAMES';
 import { Playground } from '~/helpers/playground';
+import THEME_ACT from '~/styles/themeAct';
+import THEME_ACT_ET from '~/styles/themeActEt';
+import THEME_ENCOURA_CLASSIC from '~/styles/themeEncouraClassic';
+import THEME_ENCOURAGE_V2 from '~/styles/themeEncourage';
 
 import {
   defaultBarKeys,
@@ -88,40 +93,90 @@ export const UngroupedStackedBarChart: StoryObj<StackedBarChartProps> = {
   },
 };
 
-export const VerticalBarChart: StoryObj<StackedBarChartProps> = {
-  args: {
-    barChartProps: {
-      chartProps: { layout: 'horizontal', margin: { left: 0 } },
-      maxHeight: 'auto',
-      xAxisProps: {
-        axisLine: true,
-        dataKey: 'name',
-        dy: 10,
-        orientation: 'bottom',
-        style: {
-          fill: '#003359',
-          fontSize: '14px',
-          fontWeight: 500,
+const getMergedSubLabelProps = (
+  subLabelProps: StackedBarChartProps['subLabelProps'],
+  globals: StoryContext['globals'],
+) => {
+  const theme = globals.theme;
+  let newSubLabelProps;
+
+  switch (theme) {
+    case 'ACT': {
+      newSubLabelProps =
+        THEME_ACT?.components?.[DLS_COMPONENT_NAMES.STACKED_BAR_CHART]
+          ?.defaultProps?.subLabelProps;
+      break;
+    }
+    case 'ACT_ET': {
+      newSubLabelProps =
+        THEME_ACT_ET?.components?.[DLS_COMPONENT_NAMES.STACKED_BAR_CHART]
+          ?.defaultProps?.subLabelProps;
+      break;
+    }
+    case 'ENCOURAGE': {
+      newSubLabelProps =
+        THEME_ENCOURAGE_V2?.components?.[DLS_COMPONENT_NAMES.STACKED_BAR_CHART]
+          ?.defaultProps?.subLabelProps;
+      break;
+    }
+    default: {
+      newSubLabelProps =
+        THEME_ENCOURA_CLASSIC?.components?.[
+          DLS_COMPONENT_NAMES.STACKED_BAR_CHART
+        ]?.defaultProps?.subLabelProps;
+    }
+  }
+
+  return { ...subLabelProps, ...newSubLabelProps };
+};
+
+export const VerticalBarChart = (
+  args: StackedBarChartProps,
+  context: StoryContext,
+) => {
+  const subLabelProps = {
+    position: 'bottom',
+  } as StackedBarChartProps['subLabelProps'];
+  const mergedSubLabelProps = getMergedSubLabelProps(
+    subLabelProps,
+    context.globals,
+  );
+  return (
+    <StackedBarChart
+      {...args}
+      barChartProps={{
+        chartProps: { layout: 'horizontal', margin: { left: 0 } },
+        maxHeight: 'auto',
+        xAxisProps: {
+          axisLine: true,
+          dataKey: 'name',
+          dy: 10,
+          orientation: 'bottom',
+          style: {
+            fill: '#003359',
+            fontSize: '14px',
+            fontWeight: 500,
+          },
+          tickLine: false,
+          type: 'category',
         },
-        tickLine: false,
-        type: 'category',
-      },
-      yAxisProps: {
-        dataKey: undefined,
-        dx: 0,
-        padding: { bottom: 0, top: 0 },
-        style: {
-          fill: '#555',
-          fontSize: '10px',
+        yAxisProps: {
+          dataKey: undefined,
+          dx: 0,
+          padding: { bottom: 0, top: 0 },
+          style: {
+            fill: '#555',
+            fontSize: '10px',
+          },
+          type: 'number',
         },
-        type: 'number',
-      },
-    },
-    barKeys: defaultBarKeys,
-    data: defaultData,
-    labelListProps: { position: 'insideTop' },
-    subLabelProps: { position: 'bottom' },
-  },
+      }}
+      barKeys={defaultBarKeys}
+      data={defaultData}
+      labelListProps={{ position: 'insideTop' }}
+      subLabelProps={mergedSubLabelProps}
+    />
+  );
 };
 
 export const LongLabel: StoryObj<StackedBarChartProps> = {

--- a/src/components/StackedBarChart/index.stories.tsx
+++ b/src/components/StackedBarChart/index.stories.tsx
@@ -96,8 +96,8 @@ export const UngroupedStackedBarChart: StoryObj<StackedBarChartProps> = {
 const getMergedSubLabelProps = (
   subLabelProps: StackedBarChartProps['subLabelProps'],
   globals: StoryContext['globals'],
-) => {
-  const theme = globals.theme;
+): StackedBarChartProps['subLabelProps'] => {
+  const { theme } = globals;
   let newSubLabelProps;
 
   switch (theme) {
@@ -133,14 +133,12 @@ const getMergedSubLabelProps = (
 export const VerticalBarChart = (
   args: StackedBarChartProps,
   context: StoryContext,
-) => {
+): JSX.Element => {
+  const { globals } = context;
   const subLabelProps = {
     position: 'bottom',
   } as StackedBarChartProps['subLabelProps'];
-  const mergedSubLabelProps = getMergedSubLabelProps(
-    subLabelProps,
-    context.globals,
-  );
+  const mergedSubLabelProps = getMergedSubLabelProps(subLabelProps, globals);
   return (
     <StackedBarChart
       {...args}

--- a/src/components/StackedBarChart/index.tsx
+++ b/src/components/StackedBarChart/index.tsx
@@ -7,7 +7,6 @@
  * @prettier
  */
 
-import { Typography } from '@mui/material';
 import { useTheme, useThemeProps } from '@mui/material/styles';
 import numeral from 'numeral';
 import React, { useMemo } from 'react';
@@ -24,12 +23,15 @@ import DEFAULT_CHART_COLORS from '~/constants/DEFAULT_CHART_COLORS';
 import DLS_COMPONENT_NAMES from '~/constants/DLS_COMPONENT_NAMES';
 import { ILabelListData } from '~/types';
 
+import { StyledTooltipText } from './styles';
+
 export interface StackedBarChartProps {
   barChartProps?: Omit<BarChartProps, 'data'>;
   barKeys?: Array<Array<string>>;
   barProps?: BarProps;
   children?: React.ReactElement<unknown>;
   colors?: string[];
+  customizeBarText?: (index: number) => React.CSSProperties;
   data: Array<DataProps>;
   labelListProps?: LabelListProps<ILabelListData>;
   setTooltipBarId?: (value: string | undefined) => void;
@@ -47,6 +49,7 @@ export const StackedBarChart: React.FC<StackedBarChartProps> = (
     barProps,
     children,
     colors = [],
+    customizeBarText,
     data,
     labelListProps,
     setTooltipBarId,
@@ -83,7 +86,7 @@ export const StackedBarChart: React.FC<StackedBarChartProps> = (
       subLabelKeys.reduce((acc, key) => {
         // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         const textWidth = measureText(
-          `${typography.caption.fontSize}px ${typography.fontFamily}`,
+          `${subLabelProps?.style?.fontSize || typography.body1.fontSize}px ${typography.fontFamily}`,
           key.toLocaleString(),
         );
         if (textWidth > acc) {
@@ -91,7 +94,7 @@ export const StackedBarChart: React.FC<StackedBarChartProps> = (
         }
         return acc;
       }, 0),
-    [subLabelKeys, typography.caption.fontSize, typography.fontFamily],
+    [subLabelKeys, subLabelProps?.style?.fontSize, typography.fontFamily],
   );
 
   const renderAdditionalTooltipInfo = (
@@ -108,12 +111,11 @@ export const StackedBarChart: React.FC<StackedBarChartProps> = (
     }
 
     return keys.map(key => (
-      <Typography key={key}>
+      <StyledTooltipText key={key}>
         {key} Value: {numeral(info.payload[key]).format('0,0')}
-      </Typography>
+      </StyledTooltipText>
     ));
   };
-
   return (
     <BarChart
       chartProps={{ barGap: 4 }}
@@ -172,10 +174,7 @@ export const StackedBarChart: React.FC<StackedBarChartProps> = (
                     }
                   }}
                   position="insideRight"
-                  style={{
-                    fill: i === 2 ? palette.common.white : palette.common.black,
-                    fontSize: typography.caption.fontSize,
-                  }}
+                  style={customizeBarText ? customizeBarText(i) : {}}
                   valueAccessor={(
                     bar: BarLabelProps,
                   ): string | number | undefined =>
@@ -186,10 +185,6 @@ export const StackedBarChart: React.FC<StackedBarChartProps> = (
                 {barKeys.length > 1 && i === 0 ? (
                   <LabelList
                     position="left"
-                    style={{
-                      fill: palette.common.black,
-                      fontSize: typography.caption.fontSize,
-                    }}
                     valueAccessor={(bar: BarLabelProps): string =>
                       subLabels
                         ? subLabels[index]
@@ -214,6 +209,7 @@ StackedBarChart.defaultProps = {
   barProps: undefined,
   children: undefined,
   colors: undefined,
+  customizeBarText: undefined,
   labelListProps: undefined,
   setTooltipBarId: undefined,
   subLabelProps: undefined,

--- a/src/components/StackedBarChart/styles.ts
+++ b/src/components/StackedBarChart/styles.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) ACT, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @prettier
+ */
+
+/* eslint-disable import/prefer-default-export */
+
+import { Typography, TypographyProps } from '@mui/material';
+import { styled } from '@mui/material/styles';
+
+import DLS_COMPONENT_NAMES from '~/constants/DLS_COMPONENT_NAMES';
+import DLS_COMPONENT_SLOT_NAMES from '~/constants/DLS_COMPONENT_SLOT_NAMES';
+
+export const StyledTooltipText = styled(Typography, {
+  name: DLS_COMPONENT_NAMES.STACKED_BAR_CHART,
+  slot: DLS_COMPONENT_SLOT_NAMES[DLS_COMPONENT_NAMES.STACKED_BAR_CHART]
+    .TOOLTIP_TEXT,
+})<TypographyProps>(({ theme }) => ({
+  fontSize: theme.typography.body1.fontSize,
+}));

--- a/src/constants/DLS_COMPONENT_SLOT_NAMES.ts
+++ b/src/constants/DLS_COMPONENT_SLOT_NAMES.ts
@@ -15,6 +15,9 @@ export const DLS_COMPONENT_SLOT_NAMES = {
   [DLS_COMPONENT_NAMES.BAR_CHART]: {
     Y_AXIS_LABEL: 'yAxisLabel',
   },
+  [DLS_COMPONENT_NAMES.OVERLAPPED_BAR_CHART]: {
+    BAR_LABELS: 'barLabels',
+  },
 } as const;
 
 export default DLS_COMPONENT_SLOT_NAMES;

--- a/src/constants/DLS_COMPONENT_SLOT_NAMES.ts
+++ b/src/constants/DLS_COMPONENT_SLOT_NAMES.ts
@@ -18,6 +18,11 @@ export const DLS_COMPONENT_SLOT_NAMES = {
   [DLS_COMPONENT_NAMES.OVERLAPPED_BAR_CHART]: {
     BAR_LABELS: 'barLabels',
   },
+  [DLS_COMPONENT_NAMES.SCATTER_PLOT]: {
+    SCATTER_LABELS: 'scatterLabels',
+    SCATTER_TOOLTIP_LABEL: 'scatterToolTipLabel',
+    SCATTER_TOOLTIP_TEXT: 'scatterToolTipText',
+  },
 } as const;
 
 export default DLS_COMPONENT_SLOT_NAMES;

--- a/src/constants/DLS_COMPONENT_SLOT_NAMES.ts
+++ b/src/constants/DLS_COMPONENT_SLOT_NAMES.ts
@@ -18,6 +18,9 @@ export const DLS_COMPONENT_SLOT_NAMES = {
   [DLS_COMPONENT_NAMES.OVERLAPPED_BAR_CHART]: {
     BAR_LABELS: 'barLabels',
   },
+  [DLS_COMPONENT_NAMES.PIE_CHART]: {
+    TITLE_TEXT: 'titleText',
+  },
   [DLS_COMPONENT_NAMES.SCATTER_PLOT]: {
     SCATTER_LABELS: 'scatterLabels',
     SCATTER_TOOLTIP_LABEL: 'scatterToolTipLabel',

--- a/src/constants/DLS_COMPONENT_SLOT_NAMES.ts
+++ b/src/constants/DLS_COMPONENT_SLOT_NAMES.ts
@@ -23,6 +23,9 @@ export const DLS_COMPONENT_SLOT_NAMES = {
     SCATTER_TOOLTIP_LABEL: 'scatterToolTipLabel',
     SCATTER_TOOLTIP_TEXT: 'scatterToolTipText',
   },
+  [DLS_COMPONENT_NAMES.STACKED_BAR_CHART]: {
+    TOOLTIP_TEXT: 'tooltipText',
+  },
 } as const;
 
 export default DLS_COMPONENT_SLOT_NAMES;

--- a/src/constants/DLS_COMPONENT_SLOT_NAMES.ts
+++ b/src/constants/DLS_COMPONENT_SLOT_NAMES.ts
@@ -19,6 +19,7 @@ export const DLS_COMPONENT_SLOT_NAMES = {
     BAR_LABELS: 'barLabels',
   },
   [DLS_COMPONENT_NAMES.PIE_CHART]: {
+    PIE_LEGEND_LABEL: 'pieLegendLabel',
     TITLE_TEXT: 'titleText',
   },
   [DLS_COMPONENT_NAMES.SCATTER_PLOT]: {

--- a/src/constants/DLS_COMPONENT_SLOT_NAMES.ts
+++ b/src/constants/DLS_COMPONENT_SLOT_NAMES.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) ACT, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @prettier
+ */
+
+/* eslint-disable filenames/match-exported */
+
+import DLS_COMPONENT_NAMES from '~/constants/DLS_COMPONENT_NAMES';
+
+export const DLS_COMPONENT_SLOT_NAMES = {
+  [DLS_COMPONENT_NAMES.BAR_CHART]: {
+    Y_AXIS_LABEL: 'yAxisLabel',
+  },
+} as const;
+
+export default DLS_COMPONENT_SLOT_NAMES;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -11,4 +11,5 @@
 
 export * from './DEFAULT_CHART_COLORS';
 export * from './DLS_COMPONENT_NAMES';
+export * from './DLS_COMPONENT_SLOT_NAMES';
 export * from './SORT_DIRECTION_TYPES';

--- a/src/styles/themeAct/components.ts
+++ b/src/styles/themeAct/components.ts
@@ -6,17 +6,24 @@
  *
  * @prettier
  */
-
+import type {} from '@mui/lab/themeAugmentation';
 import { common } from '@mui/material/colors';
 import { Components } from '@mui/material/styles';
+import type {} from '@mui/x-data-grid/themeAugmentation';
+
+import DLS_COMPONENT_NAMES from '~/constants/DLS_COMPONENT_NAMES';
 
 import CUSTOM_DIMS from './customDims';
 import { COLORS } from './palette';
 
-import type {} from '@mui/lab/themeAugmentation';
-import type {} from '@mui/x-data-grid/themeAugmentation';
-
 export const components: Components = {
+  [DLS_COMPONENT_NAMES.BAR_CHART]: {
+    defaultProps: {
+      yAxisProps: {
+        width: 85,
+      },
+    },
+  },
   MuiAccordion: {
     defaultProps: {},
     styleOverrides: {},

--- a/src/styles/themeAct/components.ts
+++ b/src/styles/themeAct/components.ts
@@ -7,13 +7,14 @@
  * @prettier
  */
 
-import { common } from '@mui/material/colors';
+import { common, grey } from '@mui/material/colors';
 import { Components } from '@mui/material/styles';
 
 import DLS_COMPONENT_NAMES from '~/constants/DLS_COMPONENT_NAMES';
 
 import CUSTOM_DIMS from './customDims';
 import { COLORS } from './palette';
+import TYPOGRAPHY from './typography';
 
 import type {} from '@mui/lab/themeAugmentation';
 import type {} from '@mui/x-data-grid/themeAugmentation';
@@ -21,6 +22,12 @@ import type {} from '@mui/x-data-grid/themeAugmentation';
 export const components: Components = {
   [DLS_COMPONENT_NAMES.BAR_CHART]: {
     defaultProps: {
+      xAxisProps: {
+        style: {
+          fill: grey[700],
+          fontSize: TYPOGRAPHY?.body2?.fontSize,
+        },
+      },
       yAxisProps: {
         width: 85,
       },

--- a/src/styles/themeAct/components.ts
+++ b/src/styles/themeAct/components.ts
@@ -33,6 +33,23 @@ export const components: Components = {
       },
     },
   },
+  [DLS_COMPONENT_NAMES.LINE_CHART]: {
+    defaultProps: {
+      xAxisProps: {
+        style: {
+          fill: grey[700],
+          fontSize: TYPOGRAPHY?.body2?.fontSize,
+        },
+      },
+      yAxisProps: {
+        style: {
+          fill: grey[700],
+          fontSize: TYPOGRAPHY?.body2?.fontSize,
+          fontWeight: TYPOGRAPHY?.fontWeightRegular,
+        },
+      },
+    },
+  },
   MuiAccordion: {
     defaultProps: {},
     styleOverrides: {},

--- a/src/styles/themeAct/components.ts
+++ b/src/styles/themeAct/components.ts
@@ -6,15 +6,17 @@
  *
  * @prettier
  */
-import type {} from '@mui/lab/themeAugmentation';
+
 import { common } from '@mui/material/colors';
 import { Components } from '@mui/material/styles';
-import type {} from '@mui/x-data-grid/themeAugmentation';
 
 import DLS_COMPONENT_NAMES from '~/constants/DLS_COMPONENT_NAMES';
 
 import CUSTOM_DIMS from './customDims';
 import { COLORS } from './palette';
+
+import type {} from '@mui/lab/themeAugmentation';
+import type {} from '@mui/x-data-grid/themeAugmentation';
 
 export const components: Components = {
   [DLS_COMPONENT_NAMES.BAR_CHART]: {

--- a/src/styles/themeAct/components.ts
+++ b/src/styles/themeAct/components.ts
@@ -50,6 +50,20 @@ export const components: Components = {
       },
     },
   },
+  [DLS_COMPONENT_NAMES.STACKED_BAR_CHART]: {
+    defaultProps: {
+      customizeBarText: i => ({
+        fill: i === 2 ? common.white : common.black,
+        fontSize: TYPOGRAPHY?.body2?.fontSize,
+      }),
+      subLabelProps: {
+        style: {
+          fill: common.black,
+          fontSize: TYPOGRAPHY?.body2?.fontSize,
+        },
+      },
+    },
+  },
   MuiAccordion: {
     defaultProps: {},
     styleOverrides: {},

--- a/src/styles/themeActEt/components.ts
+++ b/src/styles/themeActEt/components.ts
@@ -10,17 +10,33 @@
 import { common, grey } from '@mui/material/colors';
 import { Components } from '@mui/material/styles';
 import Color from 'color';
+
+import DLS_COMPONENT_NAMES from '~/constants/DLS_COMPONENT_NAMES';
 import FilterVariant from '~/icons/FilterVariant';
 
 import CUSTOM_DIMS from './customDims';
 import { COLORS } from './palette';
 import SHAPE from './shape';
 import spacing from './spacing';
+import TYPOGRAPHY from './typography';
 
 import type {} from '@mui/lab/themeAugmentation';
 import type {} from '@mui/x-data-grid/themeAugmentation';
 
 export const components: Components = {
+  [DLS_COMPONENT_NAMES.BAR_CHART]: {
+    defaultProps: {
+      xAxisProps: {
+        style: {
+          fill: grey[700],
+          fontSize: TYPOGRAPHY?.caption?.fontSize,
+        },
+      },
+      yAxisProps: {
+        width: 85,
+      },
+    },
+  },
   MuiAccordion: {
     defaultProps: {},
     styleOverrides: {},

--- a/src/styles/themeActEt/components.ts
+++ b/src/styles/themeActEt/components.ts
@@ -37,6 +37,23 @@ export const components: Components = {
       },
     },
   },
+  [DLS_COMPONENT_NAMES.LINE_CHART]: {
+    defaultProps: {
+      xAxisProps: {
+        style: {
+          fill: grey[700],
+          fontSize: TYPOGRAPHY?.caption?.fontSize,
+        },
+      },
+      yAxisProps: {
+        style: {
+          fill: grey[700],
+          fontSize: TYPOGRAPHY?.caption?.fontSize,
+          fontWeight: TYPOGRAPHY?.fontWeightRegular,
+        },
+      },
+    },
+  },
   MuiAccordion: {
     defaultProps: {},
     styleOverrides: {},

--- a/src/styles/themeActEt/components.ts
+++ b/src/styles/themeActEt/components.ts
@@ -54,6 +54,12 @@ export const components: Components = {
       },
     },
   },
+  [DLS_COMPONENT_NAMES.PIE_CHART]: {
+    defaultProps: {
+      chartLegendTextFontSize: TYPOGRAPHY?.body2?.fontSize,
+      chartLegendTextFontSizeSmall: TYPOGRAPHY?.caption?.fontSize,
+    },
+  },
   [DLS_COMPONENT_NAMES.STACKED_BAR_CHART]: {
     defaultProps: {
       customizeBarText: i => ({

--- a/src/styles/themeActEt/components.ts
+++ b/src/styles/themeActEt/components.ts
@@ -54,6 +54,20 @@ export const components: Components = {
       },
     },
   },
+  [DLS_COMPONENT_NAMES.STACKED_BAR_CHART]: {
+    defaultProps: {
+      customizeBarText: i => ({
+        fill: i === 2 ? common.white : common.black,
+        fontSize: TYPOGRAPHY?.caption?.fontSize,
+      }),
+      subLabelProps: {
+        style: {
+          fill: common.black,
+          fontSize: TYPOGRAPHY?.caption?.fontSize,
+        },
+      },
+    },
+  },
   MuiAccordion: {
     defaultProps: {},
     styleOverrides: {},

--- a/src/styles/themeEncoura/components.ts
+++ b/src/styles/themeEncoura/components.ts
@@ -12,6 +12,7 @@ import { Components } from '@mui/material/styles';
 import Color from 'color';
 
 import DLS_COMPONENT_NAMES from '~/constants/DLS_COMPONENT_NAMES';
+import DLS_COMPONENT_SLOT_NAMES from '~/constants/DLS_COMPONENT_SLOT_NAMES';
 import THEME_ENCOURA_CLASSIC from '~/styles/themeEncouraClassic';
 
 import COLORS, { secondaryMain } from './colors';
@@ -25,6 +26,11 @@ const COMPONENTS: Components = {
   [DLS_COMPONENT_NAMES.BAR_CHART]: {
     defaultProps: {
       colors: COLORS.CHART.primary,
+    },
+    styleOverrides: {
+      [DLS_COMPONENT_SLOT_NAMES[DLS_COMPONENT_NAMES.BAR_CHART].Y_AXIS_LABEL]: {
+        fontSize: THEME_ENCOURA_CLASSIC.typography.h3.fontSize,
+      },
     },
   },
   [DLS_COMPONENT_NAMES.HEAT_MAP]: {

--- a/src/styles/themeEncoura/components.ts
+++ b/src/styles/themeEncoura/components.ts
@@ -12,7 +12,6 @@ import { Components } from '@mui/material/styles';
 import Color from 'color';
 
 import DLS_COMPONENT_NAMES from '~/constants/DLS_COMPONENT_NAMES';
-import DLS_COMPONENT_SLOT_NAMES from '~/constants/DLS_COMPONENT_SLOT_NAMES';
 import THEME_ENCOURA_CLASSIC from '~/styles/themeEncouraClassic';
 
 import COLORS, { secondaryMain } from './colors';
@@ -26,11 +25,6 @@ const COMPONENTS: Components = {
   [DLS_COMPONENT_NAMES.BAR_CHART]: {
     defaultProps: {
       colors: COLORS.CHART.primary,
-    },
-    styleOverrides: {
-      [DLS_COMPONENT_SLOT_NAMES[DLS_COMPONENT_NAMES.BAR_CHART].Y_AXIS_LABEL]: {
-        fontSize: THEME_ENCOURA_CLASSIC.typography.h3.fontSize,
-      },
     },
   },
   [DLS_COMPONENT_NAMES.HEAT_MAP]: {

--- a/src/styles/themeEncouraClassic/components.ts
+++ b/src/styles/themeEncouraClassic/components.ts
@@ -8,6 +8,7 @@
  */
 
 import { common, grey } from '@mui/material/colors';
+import { listItemTextClasses } from '@mui/material/ListItemText';
 import { Components } from '@mui/material/styles';
 import Color from 'color';
 import ChevronDown from '~/icons/ChevronDown';
@@ -88,12 +89,24 @@ export const components: Components = {
   },
   [DLS_COMPONENT_NAMES.PIE_CHART]: {
     defaultProps: {
+      chartLegendTextFontSize: TYPOGRAPHY?.h4?.fontSize,
+      chartLegendTextFontSizeSmall: TYPOGRAPHY?.h5?.fontSize,
       tooltipProps: {
         itemStyle: { color: PALETTE.secondary.dark },
         labelStyle: { color: PALETTE.secondary.dark },
       },
     },
     styleOverrides: {
+      [DLS_COMPONENT_SLOT_NAMES[DLS_COMPONENT_NAMES.PIE_CHART]
+        .PIE_LEGEND_LABEL]: {
+        [`& .${listItemTextClasses.primary}`]: {
+          color: PALETTE.secondary.dark,
+          fontWeight: TYPOGRAPHY?.fontWeightBold,
+        },
+        [`& .${listItemTextClasses.secondary}`]: {
+          color: grey[700],
+        },
+      },
       [DLS_COMPONENT_SLOT_NAMES[DLS_COMPONENT_NAMES.PIE_CHART].TITLE_TEXT]: {
         color: PALETTE.secondary.dark,
         fontWeight: TYPOGRAPHY?.fontWeightBold,

--- a/src/styles/themeEncouraClassic/components.ts
+++ b/src/styles/themeEncouraClassic/components.ts
@@ -86,6 +86,21 @@ export const components: Components = {
       },
     },
   },
+  [DLS_COMPONENT_NAMES.PIE_CHART]: {
+    defaultProps: {
+      tooltipProps: {
+        itemStyle: { color: PALETTE.secondary.dark },
+        labelStyle: { color: PALETTE.secondary.dark },
+      },
+    },
+    styleOverrides: {
+      [DLS_COMPONENT_SLOT_NAMES[DLS_COMPONENT_NAMES.PIE_CHART].TITLE_TEXT]: {
+        color: PALETTE.secondary.dark,
+        fontWeight: TYPOGRAPHY?.fontWeightBold,
+        fontSize: TYPOGRAPHY?.body2?.fontSize,
+      },
+    },
+  },
   [DLS_COMPONENT_NAMES.SCATTER_PLOT]: {
     defaultProps: {
       scatterLabelColor: COLORS.SECONDARY_DARK,

--- a/src/styles/themeEncouraClassic/components.ts
+++ b/src/styles/themeEncouraClassic/components.ts
@@ -58,6 +58,23 @@ export const components: Components = {
       },
     },
   },
+  [DLS_COMPONENT_NAMES.LINE_CHART]: {
+    defaultProps: {
+      xAxisProps: {
+        style: {
+          fill: grey[700],
+          fontSize: TYPOGRAPHY?.caption?.fontSize,
+        },
+      },
+      yAxisProps: {
+        style: {
+          fill: grey[700],
+          fontSize: TYPOGRAPHY?.caption?.fontSize,
+          fontWeight: TYPOGRAPHY?.fontWeightRegular,
+        },
+      },
+    },
+  },
   MuiAccordion: {
     defaultProps: {},
     styleOverrides: {},

--- a/src/styles/themeEncouraClassic/components.ts
+++ b/src/styles/themeEncouraClassic/components.ts
@@ -75,6 +75,14 @@ export const components: Components = {
       },
     },
   },
+  [DLS_COMPONENT_NAMES.OVERLAPPED_BAR_CHART]: {
+    styleOverrides: {
+      [DLS_COMPONENT_SLOT_NAMES[DLS_COMPONENT_NAMES.OVERLAPPED_BAR_CHART]
+        .BAR_LABELS]: {
+        fontSize: TYPOGRAPHY?.h3?.fontSize,
+      },
+    },
+  },
   MuiAccordion: {
     defaultProps: {},
     styleOverrides: {},

--- a/src/styles/themeEncouraClassic/components.ts
+++ b/src/styles/themeEncouraClassic/components.ts
@@ -44,6 +44,14 @@ export const components: Components = {
     },
   },
   [DLS_COMPONENT_NAMES.BAR_CHART]: {
+    defaultProps: {
+      xAxisProps: {
+        style: {
+          fill: grey[700],
+          fontSize: TYPOGRAPHY?.caption?.fontSize,
+        },
+      },
+    },
     styleOverrides: {
       [DLS_COMPONENT_SLOT_NAMES[DLS_COMPONENT_NAMES.BAR_CHART].Y_AXIS_LABEL]: {
         fontSize: TYPOGRAPHY?.h3?.fontSize,

--- a/src/styles/themeEncouraClassic/components.ts
+++ b/src/styles/themeEncouraClassic/components.ts
@@ -109,8 +109,8 @@ export const components: Components = {
       },
       [DLS_COMPONENT_SLOT_NAMES[DLS_COMPONENT_NAMES.PIE_CHART].TITLE_TEXT]: {
         color: PALETTE.secondary.dark,
-        fontWeight: TYPOGRAPHY?.fontWeightBold,
         fontSize: TYPOGRAPHY?.body2?.fontSize,
+        fontWeight: TYPOGRAPHY?.fontWeightBold,
       },
     },
   },

--- a/src/styles/themeEncouraClassic/components.ts
+++ b/src/styles/themeEncouraClassic/components.ts
@@ -28,6 +28,12 @@ import type {} from '@mui/x-data-grid/themeAugmentation';
 export const components: Components = {
   [DLS_COMPONENT_NAMES.AREA_CHART]: {
     defaultProps: {
+      xAxisProps: {
+        style: {
+          fill: COLORS.SECONDARY_DARK,
+          fontSize: TYPOGRAPHY?.caption?.fontSize,
+        },
+      },
       yAxisProps: {
         style: {
           fill: COLORS.SECONDARY_DARK,

--- a/src/styles/themeEncouraClassic/components.ts
+++ b/src/styles/themeEncouraClassic/components.ts
@@ -86,6 +86,58 @@ export const components: Components = {
       },
     },
   },
+  [DLS_COMPONENT_NAMES.SCATTER_PLOT]: {
+    defaultProps: {
+      scatterLabelColor: COLORS.SECONDARY_DARK,
+      xAverageLineLabelProps: {
+        style: {
+          fontSize: TYPOGRAPHY?.h5?.fontSize,
+          fontWeight: TYPOGRAPHY?.fontWeightRegular,
+          userSelect: 'none',
+        },
+      },
+      xAverageLineProps: {
+        stroke: grey[800],
+      },
+      xAxisProps: {
+        style: {
+          fill: common.black,
+          fontSize: TYPOGRAPHY?.caption?.fontSize,
+          fontWeight: TYPOGRAPHY?.fontWeightRegular,
+          userSelect: 'none',
+        },
+      },
+      yAverageLineLabelProps: {
+        style: {
+          fontSize: TYPOGRAPHY?.h5?.fontSize,
+          fontWeight: TYPOGRAPHY?.fontWeightRegular,
+          userSelect: 'none',
+        },
+      },
+      yAverageLineProps: {
+        stroke: grey[800],
+      },
+      yAxisProps: {
+        style: {
+          fill: common.black,
+          fontSize: TYPOGRAPHY?.caption?.fontSize,
+          fontWeight: TYPOGRAPHY?.fontWeightRegular,
+          userSelect: 'none',
+        },
+      },
+    },
+    styleOverrides: {
+      [DLS_COMPONENT_SLOT_NAMES[DLS_COMPONENT_NAMES.SCATTER_PLOT]
+        .SCATTER_LABELS]: {
+        fontSize: TYPOGRAPHY?.h3?.fontSize,
+        fontWeight: TYPOGRAPHY?.h3?.fontWeight,
+      },
+      [DLS_COMPONENT_SLOT_NAMES[DLS_COMPONENT_NAMES.SCATTER_PLOT]
+        .SCATTER_TOOLTIP_LABEL]: {
+        color: PALETTE.secondary.dark,
+      },
+    },
+  },
   MuiAccordion: {
     defaultProps: {},
     styleOverrides: {},

--- a/src/styles/themeEncouraClassic/components.ts
+++ b/src/styles/themeEncouraClassic/components.ts
@@ -7,22 +7,23 @@
  * @prettier
  */
 
-import type {} from '@mui/lab/themeAugmentation';
 import { common, grey } from '@mui/material/colors';
 import { Components } from '@mui/material/styles';
-import type {} from '@mui/x-data-grid/themeAugmentation';
 import Color from 'color';
+import ChevronDown from '~/icons/ChevronDown';
+import FilterVariant from '~/icons/FilterVariant';
 
 import DLS_COMPONENT_NAMES from '~/constants/DLS_COMPONENT_NAMES';
 import DLS_COMPONENT_SLOT_NAMES from '~/constants/DLS_COMPONENT_SLOT_NAMES';
-import ChevronDown from '~/icons/ChevronDown';
-import FilterVariant from '~/icons/FilterVariant';
 
 import CUSTOM_DIMS from './customDims';
 import { COLORS } from './palette';
 import SHAPE from './shape';
 import spacing from './spacing';
 import TYPOGRAPHY from './typography';
+
+import type {} from '@mui/lab/themeAugmentation';
+import type {} from '@mui/x-data-grid/themeAugmentation';
 
 export const components: Components = {
   [DLS_COMPONENT_NAMES.BAR_CHART]: {

--- a/src/styles/themeEncouraClassic/components.ts
+++ b/src/styles/themeEncouraClassic/components.ts
@@ -17,7 +17,7 @@ import DLS_COMPONENT_NAMES from '~/constants/DLS_COMPONENT_NAMES';
 import DLS_COMPONENT_SLOT_NAMES from '~/constants/DLS_COMPONENT_SLOT_NAMES';
 
 import CUSTOM_DIMS from './customDims';
-import { COLORS } from './palette';
+import PALETTE, { COLORS } from './palette';
 import SHAPE from './shape';
 import spacing from './spacing';
 import TYPOGRAPHY from './typography';
@@ -76,6 +76,9 @@ export const components: Components = {
     },
   },
   [DLS_COMPONENT_NAMES.OVERLAPPED_BAR_CHART]: {
+    defaultProps: {
+      barTextColors: [PALETTE.text.primary, common.white],
+    },
     styleOverrides: {
       [DLS_COMPONENT_SLOT_NAMES[DLS_COMPONENT_NAMES.OVERLAPPED_BAR_CHART]
         .BAR_LABELS]: {

--- a/src/styles/themeEncouraClassic/components.ts
+++ b/src/styles/themeEncouraClassic/components.ts
@@ -26,6 +26,17 @@ import type {} from '@mui/lab/themeAugmentation';
 import type {} from '@mui/x-data-grid/themeAugmentation';
 
 export const components: Components = {
+  [DLS_COMPONENT_NAMES.AREA_CHART]: {
+    defaultProps: {
+      yAxisProps: {
+        style: {
+          fill: COLORS.SECONDARY_DARK,
+          fontSize: TYPOGRAPHY?.h4?.fontSize,
+          fontWeight: TYPOGRAPHY?.fontWeightRegular,
+        },
+      },
+    },
+  },
   [DLS_COMPONENT_NAMES.BAR_CHART]: {
     styleOverrides: {
       [DLS_COMPONENT_SLOT_NAMES[DLS_COMPONENT_NAMES.BAR_CHART].Y_AXIS_LABEL]: {

--- a/src/styles/themeEncouraClassic/components.ts
+++ b/src/styles/themeEncouraClassic/components.ts
@@ -7,9 +7,14 @@
  * @prettier
  */
 
+import type {} from '@mui/lab/themeAugmentation';
 import { common, grey } from '@mui/material/colors';
 import { Components } from '@mui/material/styles';
+import type {} from '@mui/x-data-grid/themeAugmentation';
 import Color from 'color';
+
+import DLS_COMPONENT_NAMES from '~/constants/DLS_COMPONENT_NAMES';
+import DLS_COMPONENT_SLOT_NAMES from '~/constants/DLS_COMPONENT_SLOT_NAMES';
 import ChevronDown from '~/icons/ChevronDown';
 import FilterVariant from '~/icons/FilterVariant';
 
@@ -17,11 +22,16 @@ import CUSTOM_DIMS from './customDims';
 import { COLORS } from './palette';
 import SHAPE from './shape';
 import spacing from './spacing';
-
-import type {} from '@mui/lab/themeAugmentation';
-import type {} from '@mui/x-data-grid/themeAugmentation';
+import TYPOGRAPHY from './typography';
 
 export const components: Components = {
+  [DLS_COMPONENT_NAMES.BAR_CHART]: {
+    styleOverrides: {
+      [DLS_COMPONENT_SLOT_NAMES[DLS_COMPONENT_NAMES.BAR_CHART].Y_AXIS_LABEL]: {
+        fontSize: TYPOGRAPHY?.h3?.fontSize,
+      },
+    },
+  },
   MuiAccordion: {
     defaultProps: {},
     styleOverrides: {},

--- a/src/styles/themeEncouraClassic/components.ts
+++ b/src/styles/themeEncouraClassic/components.ts
@@ -138,6 +138,20 @@ export const components: Components = {
       },
     },
   },
+  [DLS_COMPONENT_NAMES.STACKED_BAR_CHART]: {
+    defaultProps: {
+      customizeBarText: i => ({
+        fill: i === 2 ? common.white : common.black,
+        fontSize: TYPOGRAPHY?.caption?.fontSize,
+      }),
+      subLabelProps: {
+        style: {
+          fill: common.black,
+          fontSize: TYPOGRAPHY?.caption?.fontSize,
+        },
+      },
+    },
+  },
   MuiAccordion: {
     defaultProps: {},
     styleOverrides: {},

--- a/src/styles/themeEncourage/components.ts
+++ b/src/styles/themeEncourage/components.ts
@@ -9,10 +9,12 @@
 
 import { accordionClasses } from '@mui/material/Accordion';
 import { accordionSummaryClasses } from '@mui/material/AccordionSummary';
-import { common } from '@mui/material/colors';
+import { common, grey } from '@mui/material/colors';
+import { listItemTextClasses } from '@mui/material/ListItemText';
 import { ThemeOptions } from '@mui/material/styles';
 
 import DLS_COMPONENT_NAMES from '~/constants/DLS_COMPONENT_NAMES';
+import DLS_COMPONENT_SLOT_NAMES from '~/constants/DLS_COMPONENT_SLOT_NAMES';
 import cssRadius from '~/helpers/cssRadius';
 import px from '~/helpers/px';
 import pxToNumber from '~/helpers/pxToNumber';
@@ -44,6 +46,16 @@ export const components: ThemeOptions['components'] = {
     defaultProps: {
       yAxisProps: {
         width: 76,
+      },
+    },
+  },
+  [DLS_COMPONENT_NAMES.PIE_CHART]: {
+    styleOverrides: {
+      [DLS_COMPONENT_SLOT_NAMES[DLS_COMPONENT_NAMES.PIE_CHART]
+        .PIE_LEGEND_LABEL]: {
+        [`& .${listItemTextClasses.secondary}`]: {
+          color: grey[700],
+        },
       },
     },
   },

--- a/src/styles/themeEncourage/components.ts
+++ b/src/styles/themeEncourage/components.ts
@@ -12,6 +12,7 @@ import { accordionSummaryClasses } from '@mui/material/AccordionSummary';
 import { common } from '@mui/material/colors';
 import { ThemeOptions } from '@mui/material/styles';
 
+import DLS_COMPONENT_NAMES from '~/constants/DLS_COMPONENT_NAMES';
 import cssRadius from '~/helpers/cssRadius';
 import px from '~/helpers/px';
 import pxToNumber from '~/helpers/pxToNumber';
@@ -39,6 +40,13 @@ export const LARGE_RADIUS = cssRadius(LARGE_RADIUS_VALUE);
 // Base values found here:
 // https://github.com/act-org/dls/blob/main/src/styles/themeActEt/components.ts
 export const components: ThemeOptions['components'] = {
+  [DLS_COMPONENT_NAMES.BAR_CHART]: {
+    defaultProps: {
+      yAxisProps: {
+        width: 76,
+      },
+    },
+  },
   MuiAccordion: {
     defaultProps: {
       square: true,


### PR DESCRIPTION
This allows users to pass in yAxisLabelTypographyProps to customize the style of the Y-Axis label. Users can also use the 'yAxisLabel' slot in their Mui Theme to customize the style. 