### PR TITLE
feat: Add averageLineXLabelUnit optional prop to ScatterPlot

### DIFF
--- a/src/components/ScatterPlot/index.tsx
+++ b/src/components/ScatterPlot/index.tsx
@@ -576,6 +576,7 @@ export const ScatterPlot: React.FC<ScatterPlotProps> = (
 };
 
 ScatterPlot.defaultProps = {
+  averageLineXLabelUnit: undefined,
   buildDataOptions: undefined,
   cartesianGridProps: undefined,
   chartProps: undefined,

--- a/src/components/ScatterPlot/index.tsx
+++ b/src/components/ScatterPlot/index.tsx
@@ -71,6 +71,7 @@ import {
 } from './types';
 
 export interface ScatterPlotProps {
+  averageLineXLabelUnit?: string;
   buildDataOptions?: IBuildDataOptions;
   cartesianGridProps?: CartesianGridProps;
   chartProps?: CategoricalChartProps;
@@ -108,6 +109,7 @@ export const ScatterPlot: React.FC<ScatterPlotProps> = (
   inProps: ScatterPlotProps,
 ) => {
   const {
+    averageLineXLabelUnit,
     cartesianGridProps,
     chartProps,
     children,
@@ -512,7 +514,7 @@ export const ScatterPlot: React.FC<ScatterPlotProps> = (
               >
                 <Label
                   position="insideBottom"
-                  value={`Top N Average: ${formatAverageLineLabel(Number(xLineCoordinates))}`}
+                  value={`Top N Average: ${formatAverageLineLabel(Number(xLineCoordinates))}${averageLineXLabelUnit || ''}`}
                   {...xAverageLineLabelProps}
                 />
               </ReferenceLine>


### PR DESCRIPTION
The new optional prop of `averageLineXLabelUnit` prop allows users to add a unit value to the Top N Average line on the X-axis. 
Example:
<img width="1424" alt="image" src="https://github.com/act-org/dls/assets/39137653/8938134f-0afc-4927-b816-b01f1482de4f">
