### PR TITLE
fix: Fix MapPopup props

### DIFF
--- a/src/components/CountyMap/index.tsx
+++ b/src/components/CountyMap/index.tsx
@@ -134,10 +134,8 @@ export const CountyMap: React.FC<CountyMapProps> = ({
         (isString(parentWidth) ||
           parentWidth > breakpoints.values.sm - parseInt(spacing(12), 10)) ? (
           <MapPopup
-            popupProps={{
-              latitude: finalHoverInfo.lat,
-              longitude: finalHoverInfo.lng,
-            }}
+            latitude={finalHoverInfo.lat}
+            longitude={finalHoverInfo.lng}
             rows={[
               {
                 title: 'County',

--- a/src/components/GeomarketMap/index.tsx
+++ b/src/components/GeomarketMap/index.tsx
@@ -126,10 +126,8 @@ export const GeomarketMap: React.FC<GeomarketMapProps> = ({
         (isString(parentWidth) ||
           parentWidth > breakpoints.values.sm - parseInt(spacing(12), 10)) ? (
           <MapPopup
-            popupProps={{
-              latitude: finalHoverInfo.lat,
-              longitude: finalHoverInfo.lng,
-            }}
+            latitude={finalHoverInfo.lat}
+            longitude={finalHoverInfo.lng}
             rows={[
               {
                 title: 'Geomarket',

--- a/src/components/HeatMap/index.tsx
+++ b/src/components/HeatMap/index.tsx
@@ -241,10 +241,8 @@ export const HeatMap: React.FC<HeatMapProps> = (
       {tooltipElement ||
         (finalHoverInfo && lastZoom && lastZoom >= MIN_ZOOM ? (
           <MapPopup
-            popupProps={{
-              latitude: finalHoverInfo.lat,
-              longitude: finalHoverInfo.lng,
-            }}
+            latitude={finalHoverInfo.lat}
+            longitude={finalHoverInfo.lng}
             rows={[
               {
                 title: 'ZIP Code',

--- a/src/components/MapPopup/index.test.tsx
+++ b/src/components/MapPopup/index.test.tsx
@@ -14,7 +14,8 @@ import { MapPopup } from '.';
 describe.skip('MapPopup', () => {
   const Component = (
     <MapPopup
-      popupProps={{ latitude: 40, longitude: -100 }}
+      latitude={40}
+      longitude={100}
       rows={[
         {
           title: 'Test',

--- a/src/components/MapPopup/index.tsx
+++ b/src/components/MapPopup/index.tsx
@@ -17,17 +17,16 @@ export interface RowsDataProps {
   value: string | number | undefined;
 }
 
-export interface MapPopupProps {
-  popupProps: PopupProps;
+export interface MapPopupProps extends PopupProps {
   rows?: Array<RowsDataProps>;
 }
 
 export const MapPopup: React.FC<MapPopupProps> = ({
-  popupProps,
   rows,
+  ...props
 }: MapPopupProps): React.ReactElement<unknown> | null => {
   return rows ? (
-    <StyledPopup closeButton={false} closeOnClick={false} {...popupProps}>
+    <StyledPopup closeButton={false} closeOnClick={false} {...props}>
       {rows.map(row => (
         <StyledTypography key={row.title} variant="body2">
           {row.title}:<StyledSpan>{row.value}</StyledSpan>

--- a/src/components/SCFMap/index.tsx
+++ b/src/components/SCFMap/index.tsx
@@ -127,10 +127,8 @@ export const SCFMap: React.FC<SCFMapProps> = ({
         (isString(parentWidth) ||
           parentWidth > breakpoints.values.sm - parseInt(spacing(12), 10)) ? (
           <MapPopup
-            popupProps={{
-              latitude: finalHoverInfo.lat,
-              longitude: finalHoverInfo.lng,
-            }}
+            latitude={finalHoverInfo.lat}
+            longitude={finalHoverInfo.lng}
             rows={[
               {
                 title: 'SCF Code',

--- a/src/components/StateMap/index.tsx
+++ b/src/components/StateMap/index.tsx
@@ -125,10 +125,8 @@ export const StateMap: React.FC<StateMapProps> = ({
         (isString(parentWidth) ||
           parentWidth > breakpoints.values.sm - parseInt(spacing(12), 10)) ? (
           <MapPopup
-            popupProps={{
-              latitude: finalHoverInfo.lat,
-              longitude: finalHoverInfo.lng,
-            }}
+            latitude={finalHoverInfo.lat}
+            longitude={finalHoverInfo.lng}
             rows={[
               {
                 title: 'State',


### PR DESCRIPTION
Required to fix a bug on Insights Cloud, currently we don't have access to <Popup /> style prop without the need to reassign latitude and longitude values. 

https://nrccua.atlassian.net/jira/software/c/projects/IC/boards/200?assignee=619cf9b22278e7006bb43e4a&selectedIssue=IC-4087