### PR TITLE
feat: Add titleGridContainerProps optional property to Empty State

### DIFF
--- a/src/components/EmptyState/index.stories.tsx
+++ b/src/components/EmptyState/index.stories.tsx
@@ -60,3 +60,13 @@ export const CustomIcon: StoryObj<EmptyStateProps> = {
     },
   },
 };
+
+export const CustomTitleContainer: StoryObj<EmptyStateProps> = {
+  args: {
+    title:
+      'This is a very long title to demonstrate that the title container will expand to fit the content.',
+    titleGridContainerProps: {
+      maxWidth: 'unset !important',
+    },
+  },
+};

--- a/src/components/EmptyState/index.tsx
+++ b/src/components/EmptyState/index.tsx
@@ -10,6 +10,7 @@
 import Button, { ButtonProps } from '@mui/material/Button';
 import { IconProps } from '@mui/material/Icon';
 import { TypographyProps } from '@mui/material/Typography';
+import { GridProps, SizingProps } from '@mui/system';
 import { isString } from 'lodash';
 import {
   ComponentClass,
@@ -37,6 +38,7 @@ export interface EmptyStateProps {
   iconProps?: IconProps;
   style?: CSSProperties;
   title?: string | ReactElement<unknown>;
+  titleGridContainerProps?: GridProps & SizingProps;
   titleTypographyProps?: TypographyProps & {
     component?: string;
   };
@@ -50,6 +52,7 @@ export const EmptyState: FC<EmptyStateProps> = ({
   iconProps,
   style,
   title,
+  titleGridContainerProps,
   titleTypographyProps,
 }: EmptyStateProps): ReactElement<EmptyStateProps> => {
   const StyledIcon = Icon
@@ -78,6 +81,7 @@ export const EmptyState: FC<EmptyStateProps> = ({
           alignItems="center"
           container
           justifyContent="center"
+          {...titleGridContainerProps}
         >
           <StyledGridItem item>
             <StyledTypographyTitle


### PR DESCRIPTION
The new optional prop of titleGridContainerProps allows users to change the properties of the Empty state component. It makes this part of the component more flexible, as we might have some use cases where we want the title to grow with the parent container.

