### PR TITLE
feat: Update counties.json file with new Connecticut planning regions

### DIFF
--- a/src/components/CountyMap/mocks.tsx
+++ b/src/components/CountyMap/mocks.tsx
@@ -52,7 +52,7 @@ export const defaultData = [
   },
   {
     CONVERSION_QUANTITY: 281,
-    COUNTY_NAME: 'Fairfield',
+    COUNTY_NAME: 'Capitol',
     FIPS: '09001',
     QUANTITY: 538,
     STATE_CODE: 'CT',

--- a/src/components/CountyMap/mocks.tsx
+++ b/src/components/CountyMap/mocks.tsx
@@ -53,7 +53,7 @@ export const defaultData = [
   {
     CONVERSION_QUANTITY: 281,
     COUNTY_NAME: 'Capitol',
-    FIPS: '09001',
+    FIPS: '09110',
     QUANTITY: 538,
     STATE_CODE: 'CT',
   },


### PR DESCRIPTION
Recently Connecticut stopped using counties and instead remapped the state to use 9 county-equivalent Planning Regions, each with a new name. This new counties.json file now includes the county-equivalent Planning Regions. 