### PR TITLE
feat: Add some accessibility updates to BarChart component

### DIFF
--- a/src/components/BarChart/CustomTooltip/index.tsx
+++ b/src/components/BarChart/CustomTooltip/index.tsx
@@ -102,8 +102,9 @@ export const CustomTooltip: React.FC<CustomToolTipProps> = (
           : numeral(barInfo.value).format('0,0'),
       }));
     }
+
     return (
-      <Paper elevation={1} sx={{ p: 2 }}>
+      <Paper aria-live="assertive" elevation={1} sx={{ p: 2 }} role="status">
         <Typography sx={{ color: tooltipColor, mb: 0.5 }}>{label}</Typography>
 
         {showValue &&

--- a/src/components/BarChart/CustomTooltip/index.tsx
+++ b/src/components/BarChart/CustomTooltip/index.tsx
@@ -102,7 +102,6 @@ export const CustomTooltip: React.FC<CustomToolTipProps> = (
           : numeral(barInfo.value).format('0,0'),
       }));
     }
-
     return (
       <Paper aria-live="assertive" elevation={1} sx={{ p: 2 }} role="status">
         <Typography sx={{ color: tooltipColor, mb: 0.5 }}>{label}</Typography>

--- a/src/components/BarChart/index.stories.tsx
+++ b/src/components/BarChart/index.stories.tsx
@@ -30,6 +30,9 @@ export default {
   args: {
     barKeys: defaultBarKeys,
     data: defaultData,
+    description:
+      'A bar chart displaying the volumes per US state in 2019, 2020, and 2021',
+    title: 'Volumes for US States',
   },
   argTypes: Playground(
     {

--- a/src/components/BarChart/index.tsx
+++ b/src/components/BarChart/index.tsx
@@ -9,7 +9,7 @@
 
 import { useTheme, useThemeProps } from '@mui/material/styles';
 import { TypographyProps } from '@mui/material/Typography';
-import { isFunction } from 'lodash';
+import { isFunction, kebabCase, toLower } from 'lodash';
 import numeral from 'numeral';
 import React, { useMemo } from 'react';
 import {
@@ -63,6 +63,7 @@ export interface BarChartProps {
   customizeBarFillColor?: (index: number, key: string) => string | undefined;
   customizedAxisTickProps?: CustomizedAxisTickProps;
   data: Array<DataProps>;
+  description?: string;
   height?: number | ((calculatedHeight: number) => number | undefined);
   labelListProps?: LabelListProps<ILabelListData>;
   maxHeight?: number | string;
@@ -72,6 +73,7 @@ export interface BarChartProps {
   subLabelProps?: LabelListProps<ILabelListData>;
   subLabelWidth?: number;
   subLabels?: Array<string>;
+  title?: string;
   tooltipBarId?: string;
   tooltipProps?: CustomToolTipProps;
   UnhoveredTooltipComponent?: React.JSX.Element;
@@ -113,6 +115,7 @@ export const BarChart: React.FC<BarChartProps> = (
     customizeBarFillColor,
     customizedAxisTickProps,
     data,
+    description,
     height,
     labelListProps,
     maxHeight,
@@ -121,6 +124,7 @@ export const BarChart: React.FC<BarChartProps> = (
     subLabelProps,
     subLabelWidth,
     subLabels,
+    title,
     tooltipBarId,
     tooltipProps,
     variant,
@@ -211,7 +215,7 @@ export const BarChart: React.FC<BarChartProps> = (
     composedChartLeftMargin =
       (subLabelWidth || maxSubLabelWidth) + parseInt(String(spacing(1)), 10);
   }
-
+  console.log('LabelListProps', labelListProps);
   return (
     <StyledContainer
       height={finalHeight}
@@ -229,9 +233,12 @@ export const BarChart: React.FC<BarChartProps> = (
         {...responsiveContainerProps}
       >
         <ComposedChart
+          accessibilityLayer
           barCategoryGap={DEFAULT_BAR_CATEGORY_GAP}
           barGap={DEFAULT_BAR_GAP}
           data={data}
+          desc={description}
+          id={`${title ? `${kebabCase(toLower(title))}-` : ''}bar-chart`}
           layout="vertical"
           margin={{
             bottom: parseInt(String(spacing(0.6)), 10),
@@ -240,10 +247,12 @@ export const BarChart: React.FC<BarChartProps> = (
             top: parseInt(String(spacing(2)), 10),
           }}
           maxBarSize={30}
+          role="group"
           style={{
             cursor: chartProps?.onClick ? 'pointer' : undefined,
             fontFamily: typography.fontFamily,
           }}
+          title={title}
           {...chartProps}
         >
           <CartesianGrid
@@ -254,7 +263,6 @@ export const BarChart: React.FC<BarChartProps> = (
             axisLine={false}
             orientation="top"
             tickFormatter={(v: number): string => numeral(v).format('0,0')}
-            tabIndex={0}
             type="number"
             xAxisId={0}
             {...xAxisProps}
@@ -298,12 +306,13 @@ export const BarChart: React.FC<BarChartProps> = (
                     setBarIdHovered(key);
                   }
                 }}
-                tabIndex={0}
                 {...(barProps as Omit<BarProps, 'dataKey' | 'ref'>)}
               >
+                {/* number at end of bar */}
                 <LabelList
                   dataKey={key}
                   formatter={(v: number): string => numeral(v).format('0,0')}
+                  id={`${key}-bar-label`}
                   onMouseLeave={(): void => {
                     if (setTooltipBarId) setTooltipBarId(undefined);
                     setBarIdHovered(undefined);
@@ -322,14 +331,15 @@ export const BarChart: React.FC<BarChartProps> = (
                   tabIndex={0}
                   {...labelListProps}
                 />
+                {/* year at the beginning of the bar */}
                 {barKeys.length > 1 && (
                   <LabelList
+                    id={`${key}-label`}
                     position="left"
                     style={{
                       fill: palette.grey[700],
                       fontSize: typography.caption.fontSize,
                     }}
-                    tabIndex={0}
                     valueAccessor={(bar: BarLabelProps): string =>
                       subLabels ? subLabels[i] : bar?.tooltipPayload[0]?.name
                     }

--- a/src/components/BarChart/index.tsx
+++ b/src/components/BarChart/index.tsx
@@ -215,7 +215,8 @@ export const BarChart: React.FC<BarChartProps> = (
     composedChartLeftMargin =
       (subLabelWidth || maxSubLabelWidth) + parseInt(String(spacing(1)), 10);
   }
-  console.log('LabelListProps', labelListProps);
+
+  const lowerCaseTitle = toLower(title);
   return (
     <StyledContainer
       height={finalHeight}
@@ -238,7 +239,7 @@ export const BarChart: React.FC<BarChartProps> = (
           barGap={DEFAULT_BAR_GAP}
           data={data}
           desc={description}
-          id={`${title ? `${kebabCase(toLower(title))}-` : ''}bar-chart`}
+          id={`${title ? `${kebabCase(lowerCaseTitle)}-` : ''}bar-chart`}
           layout="vertical"
           margin={{
             bottom: parseInt(String(spacing(0.6)), 10),
@@ -247,7 +248,6 @@ export const BarChart: React.FC<BarChartProps> = (
             top: parseInt(String(spacing(2)), 10),
           }}
           maxBarSize={30}
-          role="group"
           style={{
             cursor: chartProps?.onClick ? 'pointer' : undefined,
             fontFamily: typography.fontFamily,
@@ -296,7 +296,7 @@ export const BarChart: React.FC<BarChartProps> = (
                 isAnimationActive={animate}
                 key={`${key}-bar`}
                 onAnimationStart={onAnimationStart}
-                onMouseLeave={(): void => {
+                onMouseMove={(): void => {
                   if (setTooltipBarId) setTooltipBarId(undefined);
                   setBarIdHovered(undefined);
                 }}
@@ -308,7 +308,6 @@ export const BarChart: React.FC<BarChartProps> = (
                 }}
                 {...(barProps as Omit<BarProps, 'dataKey' | 'ref'>)}
               >
-                {/* number at end of bar */}
                 <LabelList
                   dataKey={key}
                   formatter={(v: number): string => numeral(v).format('0,0')}
@@ -331,7 +330,6 @@ export const BarChart: React.FC<BarChartProps> = (
                   tabIndex={0}
                   {...labelListProps}
                 />
-                {/* year at the beginning of the bar */}
                 {barKeys.length > 1 && (
                   <LabelList
                     id={`${key}-label`}
@@ -351,6 +349,7 @@ export const BarChart: React.FC<BarChartProps> = (
           })}
 
           <Tooltip
+            accessibilityLayer
             content={
               <CustomTooltip barId={tooltipBarId || barIdHovered} data={data} />
             }

--- a/src/components/BarChart/index.tsx
+++ b/src/components/BarChart/index.tsx
@@ -254,6 +254,7 @@ export const BarChart: React.FC<BarChartProps> = (
             axisLine={false}
             orientation="top"
             tickFormatter={(v: number): string => numeral(v).format('0,0')}
+            tabIndex={0}
             type="number"
             xAxisId={0}
             {...xAxisProps}
@@ -297,6 +298,7 @@ export const BarChart: React.FC<BarChartProps> = (
                     setBarIdHovered(key);
                   }
                 }}
+                tabIndex={0}
                 {...(barProps as Omit<BarProps, 'dataKey' | 'ref'>)}
               >
                 <LabelList
@@ -317,6 +319,7 @@ export const BarChart: React.FC<BarChartProps> = (
                     fill: palette.grey[700],
                     fontSize: typography.caption.fontSize,
                   }}
+                  tabIndex={0}
                   {...labelListProps}
                 />
                 {barKeys.length > 1 && (
@@ -326,6 +329,7 @@ export const BarChart: React.FC<BarChartProps> = (
                       fill: palette.grey[700],
                       fontSize: typography.caption.fontSize,
                     }}
+                    tabIndex={0}
                     valueAccessor={(bar: BarLabelProps): string =>
                       subLabels ? subLabels[i] : bar?.tooltipPayload[0]?.name
                     }


### PR DESCRIPTION
Recharts has recently published an update that [allows keyboard accessibility for certain charts](https://master--63da8268a0da9970db6992aa.chromatic.com/?path=/docs/api-accessibility--docs).  This PR adds that prop to the BarChart component and also exposes an **optional** title and description prop that screen readers can access. 

Even though the `accessibilityLayer` prop has been added to the chart it's unfortunately not yet fully keyboard accessible. After this PR is merged I will create an issue with recharts to see why it's not working as described in their documentation. They have [quite a few open accessibility issues](https://github.com/recharts/recharts/issues?q=is%3Aissue+is%3Aopen+label%3Aaccessibility) so I'm hopeful that this could be fixed in future recharts versions. 